### PR TITLE
Allow indexed paths natively

### DIFF
--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -4949,7 +4949,7 @@ end;
 
 function TwbContainer.ResolveElementName(aName: string; out aRemainingName: string; aCanCreate: Boolean = False): IwbElement;
 var
-  i, openBracketPos, closeBracketPos : Integer;
+  i : Integer;
 begin
   aRemainingName := '';
   i := Pos('\', aName);
@@ -4957,12 +4957,10 @@ begin
     aRemainingName := Copy(aName, Succ(i), High(Integer));
     Delete(aName, i, High(Integer));
   end;
-  openBracketPos := Pos('[', aName);
-  closeBracketPos := Pos(']', aName);
   if aName = '..' then
     Result := GetContainer
-  else if (openBracketPos > 0) and (closeBracketPos > 0) then begin
-    i := StrToInt(Copy(aName, openBracketPos, closeBracketPos - openBracketPos));
+  else if (aName[1] = '[') and (aName[Length(aName)] = ']') then begin
+    i := StrToInt(Copy(aName, 2, Length(aName) - 2));
     Result := GetElement(i);
   end
   else

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -4953,12 +4953,12 @@ var
 begin
   aRemainingName := '';
   i := Pos('\', aName);
-  openBracketPos := Pos('[', aName);
-  closeBracketPos := Pos(']', aName);
   if i > 0 then begin
     aRemainingName := Copy(aName, Succ(i), High(Integer));
     Delete(aName, i, High(Integer));
   end;
+  openBracketPos := Pos('[', aName);
+  closeBracketPos := Pos(']', aName);
   if aName = '..' then
     Result := GetContainer
   else if (openBracketPos > 0) and (closeBracketPos > 0) then begin

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -4949,16 +4949,22 @@ end;
 
 function TwbContainer.ResolveElementName(aName: string; out aRemainingName: string; aCanCreate: Boolean = False): IwbElement;
 var
-  i : Integer;
+  i, openBracketPos, closeBracketPos : Integer;
 begin
   aRemainingName := '';
   i := Pos('\', aName);
+  openBracketPos := Pos('[', aName);
+  closeBracketPos := Pos(']', aName);
   if i > 0 then begin
     aRemainingName := Copy(aName, Succ(i), High(Integer));
     Delete(aName, i, High(Integer));
   end;
   if aName = '..' then
     Result := GetContainer
+  else if (openBracketPos > 0) and (closeBracketPos > 0) then begin
+    i := StrToInt(Copy(aName, openBracketPos, closeBracketPos - openBracketPos));
+    Result := GetElement(i);
+  end
   else
     Result := GetElementByName(aName);
   if not Assigned(Result) and (Length(aName) = 4) then


### PR DESCRIPTION
I introduced indexed paths with mteFunctions a long time ago, and they've been used in xEdit scripts fairly heavily.  They're a fairly simple extension to element paths which allow us to use indexes in paths without having to break things into multiple queries.  E.g.

```delphi
// Assume rec is an IInterface variable holding a COBJ IwbMainRecord
// EXAMPLE 1
element := ElementByPath(rec, 'Conditions');
element := ElementByIndex(element, 0);
GetElementEditValues(element, 'CTDA\Type');
// can be shortened to:
GetElementEditValues(rec, 'Conditions\[0]\CTDA\Type');

// EXAMPLE 2
element := ElementByPath(rec, 'KWDA');
GetNativeValue(ElementByIndex(element, 2));
// can be shortened to:
GetElementNativeValues(rec, 'KWDA\[2]');
```

I think this small change should be strongly considered due to how heavily it gets used in xEdit scripting.  A native implementation would simplify things (no longer requiring me to make new versions of every function that uses paths), and would run considerably faster than the currently available script-based solution.