### PR TITLE
wrapped wbMergeSortInternal in exception handler

### DIFF
--- a/wbSort.pas
+++ b/wbSort.pas
@@ -18,7 +18,7 @@ unit wbSort;
 interface
 
 uses
-  Classes, wbInterface;
+  Classes, SysUtils, wbInterface;
 
 procedure wbMergeSort(aList: Pointer; aCount: Integer; aCompare: TListSortCompare);
 
@@ -933,13 +933,22 @@ asm
 end;
 
 
+function wbMergeSortWrapper(_A, _B: PwbPointerArray; _Count : Integer; _Compare: TListSortCompare): PwbPointerArray;
+begin
+  try
+    Result := wbMergeSortInternal(_A, _B, _Count, _Compare);
+  except
+    on x: Exception do raise Exception.Create('wbMergeSortInternal: ' + x.Message);
+  end;
+end;
+
 procedure wbMergeSort(aList: Pointer; aCount: Integer; aCompare: TListSortCompare);
 
   procedure UseStackBufferLarge;
   var
     Buffer: array[0..Pred(4 * 1024)] of Pointer;
   begin
-    if wbMergeSortInternal(aList, @Buffer[0], aCount, aCompare) <> aList then
+    if wbMergeSortWrapper(aList, @Buffer[0], aCount, aCompare) <> aList then
       Move(Buffer, aList^, aCount * SizeOf(Pointer) );
   end;
 
@@ -947,7 +956,7 @@ procedure wbMergeSort(aList: Pointer; aCount: Integer; aCompare: TListSortCompar
   var
     Buffer: array[0..Pred(1024)] of Pointer;
   begin
-    if wbMergeSortInternal(aList, @Buffer[0], aCount, aCompare) <> aList then
+    if wbMergeSortWrapper(aList, @Buffer[0], aCount, aCompare) <> aList then
       Move(Buffer, aList^, aCount * SizeOf(Pointer) );
   end;
 
@@ -959,7 +968,7 @@ begin
 
   if aCount > 4 * 1024 then begin
     GetMem(Buffer, aCount * SizeOf(Pointer));
-    if wbMergeSortInternal(aList, Buffer, aCount, aCompare) <> aList then
+    if wbMergeSortWrapper(aList, Buffer, aCount, aCompare) <> aList then
       Move(Buffer^, aList^, aCount * SizeOf(Pointer));
     FreeMem(Buffer);
   end else if aCount > 1024 then


### PR DESCRIPTION
access violations can happen in big ASM functions, and having a try-except wrapper around it makes it easier to track it down
