### PR TITLE
Allow loading only file headers

### DIFF
--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -45,7 +45,7 @@ var
 
 procedure wbMastersForFile(const aFileName: string; aMasters: TStrings);
 function wbFile(const aFileName: string; aLoadOrder: Integer = -1; aCompareTo: string = '';
-  aOnlyHeader: Boolean = False; IsTemporary: Boolean = False): IwbFile;
+  IsTemporary: Boolean = False; aOnlyHeader: Boolean = False): IwbFile;
 function wbNewFile(const aFileName: string; aLoadOrder: Integer): IwbFile;
 procedure wbFileForceClosed;
 
@@ -1767,7 +1767,7 @@ begin
 
   flProgress('Adding master "' + t + '"');
   try
-    _File := wbFile(s + t, -1, '', False, IsTemporary);
+    _File := wbFile(s + t, -1, '', IsTemporary, False);
     if wbRequireLoadOrder and (_File.LoadOrder < 0) then
       raise Exception.Create('"' + GetFileName + '" requires master "' + aFileName + '" to be loaded before it.');
     AddMaster(_File);
@@ -14809,7 +14809,7 @@ begin
 end;
 
 function wbFile(const aFileName: string; aLoadOrder: Integer = -1; aCompareTo: string = '';
-  aOnlyHeader: Boolean = False; IsTemporary: Boolean = False): IwbFile;
+  IsTemporary: Boolean = False; aOnlyHeader: Boolean = False): IwbFile;
 var
   FileName: string;
   i: Integer;

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -45,7 +45,7 @@ var
 
 procedure wbMastersForFile(const aFileName: string; aMasters: TStrings);
 function wbFile(const aFileName: string; aLoadOrder: Integer = -1; aCompareTo: string = '';
-  IsTemporary: Boolean = False): IwbFile;
+  aOnlyHeader: Boolean = False; IsTemporary: Boolean = False): IwbFile;
 function wbNewFile(const aFileName: string; aLoadOrder: Integer): IwbFile;
 procedure wbFileForceClosed;
 
@@ -1767,7 +1767,7 @@ begin
 
   flProgress('Adding master "' + t + '"');
   try
-    _File := wbFile(s + t, -1, '', IsTemporary);
+    _File := wbFile(s + t, -1, '', False, IsTemporary);
     if wbRequireLoadOrder and (_File.LoadOrder < 0) then
       raise Exception.Create('"' + GetFileName + '" requires master "' + aFileName + '" to be loaded before it.');
     AddMaster(_File);
@@ -14809,7 +14809,7 @@ begin
 end;
 
 function wbFile(const aFileName: string; aLoadOrder: Integer = -1; aCompareTo: string = '';
-  IsTemporary: Boolean = False): IwbFile;
+  aOnlyHeader: Boolean = False; IsTemporary: Boolean = False): IwbFile;
 var
   FileName: string;
   i: Integer;
@@ -14823,9 +14823,9 @@ begin
     Result := IwbFile(Pointer(FilesMap.Objects[i]))
   else begin
     if not wbIsPlugin(FileName) then
-      Result := TwbFileSource.Create(FileName, aLoadOrder, aCompareTo, False, IsTemporary)
+      Result := TwbFileSource.Create(FileName, aLoadOrder, aCompareTo, aOnlyHeader, IsTemporary)
     else
-      Result := TwbFile.Create(FileName, aLoadOrder, aCompareTo, False, IsTemporary);
+      Result := TwbFile.Create(FileName, aLoadOrder, aCompareTo, aOnlyHeader, IsTemporary);
     SetLength(Files, Succ(Length(Files)));
     Files[High(Files)] := Result;
     FilesMap.AddObject(FileName, Pointer(Result));


### PR DESCRIPTION
This is used by Merge Plugins and Mator Smash in order to evaluate basic parts of plugins during file loading.  See [mtePluginSelectionForm](https://github.com/matortheeternal/merge-plugins/blob/master/lib/mte/mtePluginSelectionForm.pas) and [mteBase L217-267](https://github.com/matortheeternal/merge-plugins/blob/master/lib/mte/mteBase.pas#L217-L267).

Merging this into the base xEdit library will make it so I don't have to monkey-patch xEdit.