### PR TITLE
wbBinarySearch

### DIFF
--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -1785,21 +1785,23 @@ end;
 
 function wbBinarySearch(aList: PwbPointerArray; L, H: Integer; aValue: Pointer; aCompare: TSearchCompare; var Index: Integer): Boolean; overload;
 var
-  C: Integer;
+  I, C: Integer;
 begin
+  Result := False;
   while L <= H do begin
-    Index := (L + H) shr 1;
-    C := aCompare(aList[Index], aValue);
+    I := (L + H) shr 1;
+    C := aCompare(aList[I], aValue);
     if C < 0 then
-      L := Index + 1
+      L := I + 1
     else begin
-      H := Index - 1;
+      H := I - 1;
       if C = 0 then begin
         Result := True;
-        Exit;
+        L := I;
       end;
     end;
   end;
+  Index := L;
 end;
 
 { TwbFile }

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -1610,7 +1610,7 @@ type
     function GetSignature: TwbSignature;
   end;
 
-  TSearchCompare = reference to function(Item1, Item2: Pointer): Integer;
+  TSearchCompare = reference to function(Item, Value: Pointer): Integer;
 
 const
   NONE : TwbSignature = #0#0#0#0;
@@ -1751,29 +1751,29 @@ begin
     Result := CmpW32(IwbFile(Item1).ElementID, IwbFile(Item2).ElementID);
 end;
 
-function SearchRecordsByEditorID(Item1, Item2: Pointer): Integer;
+function SearchRecordsByEditorID(Item, Value: Pointer): Integer;
 begin
-  Result := CompareText(IwbMainRecord(Item1).EditorID, String(Item2^));
+  Result := CompareText(IwbMainRecord(Item).EditorID, PString(Value)^);
 end;
 
-function SearchRecordsByFixedFormID(Item1, Item2: Pointer): Integer;
+function SearchRecordsByFixedFormID(Item, Value: Pointer): Integer;
 begin
-  Result := CmpW32(IwbMainRecord(Item1).FixedFormID, Cardinal(Item2^));
+  Result := CmpW32(IwbMainRecord(Item).FixedFormID, PCardinal(Value)^);
 end;
 
-function SearchRecordsByFormID(Item1, Item2: Pointer): Integer;
+function SearchRecordsByFormID(Item, Value: Pointer): Integer;
 begin
-  Result := CmpW32(IwbMainRecord(Item1).FormID and $00FFFFFF, Cardinal(Item2^));
+  Result := CmpW32(IwbMainRecord(Item).FormID and $00FFFFFF, PCardinal(Value)^);
 end;
 
-function SearchBySortKey(Item1, Item2: Pointer): Integer;
+function SearchBySortKey(Item, Value: Pointer): Integer;
 begin
-  Result := CompareStr(IwbElement(Item1).SortKey[False], string(Item2^));
+  Result := CompareStr(IwbElement(Item).SortKey[False], PString(Value)^);
 end;
 
-function SearchByExtendedSortKey(Item1, Item2: Pointer): Integer;
+function SearchByExtendedSortKey(Item, Value: Pointer): Integer;
 begin
-  Result := CompareStr(IwbElement(Item1).SortKey[True], string(Item2^));
+  Result := CompareStr(IwbElement(Item).SortKey[True], PString(Value)^);
 end;
 
 function SearchByRecord(Item1, Item2: Pointer): Integer;

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -73,6 +73,7 @@ var
   wbResolveAlias           : Boolean  = True;
   wbActorTemplateHide      : Boolean  = True;
   wbClampFormID            : Boolean  = True;
+  wbAllowSlowSearching     : Boolean  = False;
   wbDoNotBuildRefsFor      : TStringList;
   wbCopyIsRunning          : Integer  = 0;
 


### PR DESCRIPTION
This is a refactor which moves the binary searching which is used in several methods to its own generic function, similar to `wbMergeSort`.  The function lives in `wbImplementation`.

The following functions are adjusted to the new function, `wbBinarySearch`:

- TwbFile.FindEditorID
- TwbFile.FindFormID
- TwbFile.FindInjectedID
- TwbContainer.FindBySortKey
- TwbMainRecord.FindReferencedBy

Tested in my local development environment.

The different search comparators are implemented through a TSearchCompare function reference type.  The design is largely inspired by the design of wbMergeSort (although with no asm bits).  The code could potentially be moved into the wbSort unit.

Previously, if `flFormIDsSorted` was `False` for a file and some other code called RecordByFormID it would simply exit, though there was code present for doing a "slow" iterative search.  I added a new global configuration variable to wbInterface `wbAllowSlowSearching` which will allows this code to be reached if set to true.  The variable is `False` by default, so default behavior of the program is unchanged.