### PR TITLE
Feature/RecordsBySignature

### DIFF
--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -802,6 +802,8 @@ type
     function GetHasNoFormID: Boolean;
     procedure SetHasNoFormID(Value: Boolean);
 
+    procedure RecordsBySignature(var aList: TDynMainRecords; aSignature: String; var len: Integer);
+
     property FileName: string
       read GetFileName;
     property UnsavedSince: TDateTime

--- a/wbScriptAdapter.pas
+++ b/wbScriptAdapter.pas
@@ -1483,6 +1483,23 @@ begin
   end;
 end;
 
+procedure IwbFile_RecordsBySignature(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  _File   : IwbFile;
+  records : TDynMainRecords;
+  lst     : TList;
+  len, i  : Integer;
+begin
+  if Supports(IInterface(Args.Values[0]), IwbFile, _File) then begin
+    len := 0;
+    _File.RecordsBySignature(records, Args.Values[1], len);
+    lst := TList(V2O(Args.Values[2]));
+    for i := Low(records) to High(records) do
+      lst.Add(Pointer(records[i]));
+    Value := True;
+  end;
+end;
+
 
 { wbContainerHandler }
 
@@ -1984,6 +2001,7 @@ begin
     AddFunction(cUnit, 'LoadOrderFormIDtoFileFormID', IwbFile_LoadOrderFormIDtoFileFormID, 2, [varEmpty, varEmpty], varEmpty);
     AddFunction(cUnit, 'FileFormIDtoLoadOrderFormID', IwbFile_FileFormIDtoLoadOrderFormID, 2, [varEmpty, varString], varEmpty);
     AddFunction(cUnit, 'FileWriteToStream', IwbFile_WriteToStream, 3, [varEmpty, varEmpty, varEmpty], varEmpty);
+    AddFunction(cUnit, 'RecordsBySignature', IwbFile_RecordsBySignature, 3, [varEmpty, varEmpty, varEmpty], varEmpty);
 
     { IwbContainerHandler }
     AddFunction(cUnit, 'ResourceContainerList', IwbContainerHandler_ResourceContainerList, 1, [varEmpty], varEmpty);


### PR DESCRIPTION
This PR adds a simple function for getting all records with a particular signature from a file.  The function is exposed through the `jvInterpreter`.  I am aware that this can be accomplished with the existing function `wbGetSiblingRecords`, but I feel the lack of a member function on `IwbFile` is a bit of an oversight for other considerations (see my other PR).

I also feel that the functionality offered by this and `wbGetSiblingRecords` are suitably different to warrant both functions being present.  Getting records by signature is especially important for patching, and the lack of a function explicitly named for this functionality is not user friendly for that use case.