### PR TITLE
Feature/GetExpectedSignatures

### DIFF
--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -1609,11 +1609,14 @@ type
     ['{DC7CBC9F-07EC-430B-94EE-ECE1867A2660}']
     function GetSignature(aIndex: Integer): TwbSignature;
     function GetSignatureCount: Integer;
+    function GetSignaturesText: String;
 
     property Signatures[aIndex: Integer]: TwbSignature
       read GetSignature;
     property SignatureCount: Integer
       read GetSignatureCount;
+    property SignaturesText: String
+      read GetSignaturesText;
   end;
 
   IwbChar4 = interface(IwbIntegerDefFormater)
@@ -4779,6 +4782,7 @@ type
     {---IwbFormIDChecked---}
     function GetSignature(aIndex: Integer): TwbSignature;
     function GetSignatureCount: Integer;
+    function GetSignaturesText: String;
   end;
 
   TwbChar4 = class(TwbIntegerDefFormater, IwbChar4)
@@ -12808,6 +12812,11 @@ end;
 function TwbFormIDChecked.GetSignatureCount: Integer;
 begin
   Result := fidcValidRefs.Count;
+end;
+
+function TwbFormIDChecked.GetSignaturesText: String;
+begin
+  Result := fidcValidRefs.CommaText;
 end;
 
 function TwbFormIDChecked.IsValid(const aSignature: TwbSignature): Boolean;

--- a/wbScriptAdapter.pas
+++ b/wbScriptAdapter.pas
@@ -670,13 +670,17 @@ var
   intDef: IwbIntegerDef;
   formDef: IwbFormIDChecked;
 begin
+  Value := '';
   if Supports(IInterface(Args.Values[0]), IwbElement, Element) then begin
     def := Element.Def;
     if Supports(def, IwbSubrecordDef, subDef) then
       def := subDef.Value;
-    if Supports(def, IwbIntegerDef, intDef)
-    and Supports(intDef.Formater[element], IwbFormIDChecked, formDef) then
-      Value := formDef.SignaturesText;
+    if Supports(def, IwbIntegerDef, intDef) then begin
+      if Supports(intDef.Formater[element], IwbFormIDChecked, formDef) then
+        Value := formDef.SignaturesText
+      else if Supports(intDef.Formater[element], IwbFormID) then
+        Value := '*';
+    end;
   end;
 end;
 

--- a/wbScriptAdapter.pas
+++ b/wbScriptAdapter.pas
@@ -662,6 +662,24 @@ begin
     Element.SetToDefault;
 end;
 
+procedure IwbElement_GetExpectedSignatures(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  Element: IwbElement;
+  def: IwbNamedDef;
+  subDef: IwbSubrecordDef;
+  intDef: IwbIntegerDef;
+  formDef: IwbFormIDChecked;
+begin
+  if Supports(IInterface(Args.Values[0]), IwbElement, Element) then begin
+    def := Element.Def;
+    if Supports(def, IwbSubrecordDef, subDef) then
+      def := subDef.Value;
+    if Supports(def, IwbIntegerDef, intDef)
+    and Supports(intDef.Formater[element], IwbFormIDChecked, formDef) then
+      Value := formDef.SignaturesText;
+  end;
+end;
+
 
 procedure _wbCopyElementToFile(var Value: Variant; Args: TJvInterpreterArgs);
 var
@@ -1888,6 +1906,7 @@ begin
     AddFunction(cUnit, 'BuildRef', IwbElement_BuildRef, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'MarkModifiedRecursive', IwbElement_MarkModifiedRecursive, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'SetToDefault', IwbElement_SetToDefault, 1, [varEmpty], varEmpty);
+    AddFunction(cUnit, 'GetExpectedSignatures', IwbElement_GetExpectedSignatures, 1, [varEmpty], varEmpty);
 
     { IwbContainer }
     AddFunction(cUnit, 'GetElementEditValues', IwbContainer_GetElementEditValues, 2, [varEmpty, varString], varEmpty);


### PR DESCRIPTION
This PR adds a function to `IwbFormIDChecked` to retrieve allowed/expected signatures.  This functionality is used in [xedit-lib](https://github.com/matortheeternal/xedit-lib).  The function is used in [shampoo](https://github.com/matortheeternal/shampoo) to determine whether or not an unresolved reference (URR) can be replaced with a NULL reference without creating an unexpected reference error (UER).  I exposed the function to the jvInterpreter.

The function is useful in several circumstances including but not limited to:

- A script or external GUI needs to determine what references are allowed for a particular field to populate a reference list.
- A script or application needs to determine which references are allowed prior to setting a particular value.