### PR TITLE
Apply Last Script and Scripts Dropdown Performance

### DIFF
--- a/frmScriptForm.dfm
+++ b/frmScriptForm.dfm
@@ -44,9 +44,12 @@ object frmScript: TfrmScript
       Height = 21
       Style = csDropDownList
       Anchors = [akLeft, akTop, akRight]
+      DoubleBuffered = True
       DropDownCount = 30
+      ParentDoubleBuffered = False
       TabOrder = 0
       OnChange = cmbScriptsChange
+      OnDropDown = cmbScriptsDropdown
     end
     object btnSave: TButton
       Left = 600

--- a/frmViewMain.dfm
+++ b/frmViewMain.dfm
@@ -319,10 +319,6 @@ object frmMain: TfrmMain
         ImageIndex = 3
         TabVisible = False
         OnShow = tbsViewShow
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object lvReferencedBy: TListView
           AlignWithMargins = True
           Left = 0
@@ -365,10 +361,6 @@ object frmMain: TfrmMain
         Caption = 'Messages'
         ImageIndex = 1
         OnShow = tbsMessagesShow
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object mmoMessages: TMemo
           AlignWithMargins = True
           Left = 0
@@ -388,10 +380,6 @@ object frmMain: TfrmMain
       object tbsInfo: TTabSheet
         Caption = 'Information'
         ImageIndex = 2
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object Memo1: TMemo
           AlignWithMargins = True
           Left = 3
@@ -564,10 +552,6 @@ object frmMain: TfrmMain
         Caption = 'Weapon Spreadsheet'
         ImageIndex = 4
         OnShow = tbsSpreadsheetShow
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object vstSpreadSheetWeapon: TVirtualEditTree
           Tag = 3
           Left = 0
@@ -775,10 +759,6 @@ object frmMain: TfrmMain
         Caption = 'Armor Spreadsheet'
         ImageIndex = 5
         OnShow = tbsSpreadsheetShow
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object vstSpreadsheetArmor: TVirtualEditTree
           Tag = 3
           Left = 0
@@ -922,10 +902,6 @@ object frmMain: TfrmMain
         Caption = 'Ammunition Spreadsheet'
         ImageIndex = 6
         OnShow = tbsSpreadsheetShow
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object vstSpreadSheetAmmo: TVirtualEditTree
           Tag = 3
           Left = 0
@@ -1048,10 +1024,6 @@ object frmMain: TfrmMain
         Caption = 'TabSheet2'
         ImageIndex = 7
         TabVisible = False
-        ExplicitLeft = 0
-        ExplicitTop = 0
-        ExplicitWidth = 0
-        ExplicitHeight = 0
         object DisplayPanel: TPanel
           Left = 0
           Top = 0
@@ -1478,6 +1450,11 @@ object frmMain: TfrmMain
     object mniNavApplyScript: TMenuItem
       Caption = 'Apply Script...'
       OnClick = mniNavApplyScriptClick
+    end
+    object mniNavApplyLastScript: TMenuItem
+      Caption = 'Apply Last Script'
+      ShortCut = 120
+      OnClick = mniNavApplyLastScriptClick
     end
     object N18: TMenuItem
       Caption = '-'

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -309,6 +309,7 @@ type
     mniViewStickAuto: TMenuItem;
     mniViewStickSelected: TMenuItem;
     mniViewSetToDefault: TMenuItem;
+    mniNavApplyLastScript: TMenuItem;
 
     {--- Form ---}
     procedure FormClose(Sender: TObject; var Action: TCloseAction);
@@ -521,6 +522,7 @@ type
     procedure mniViewStickAutoClick(Sender: TObject);
     procedure mniViewStickSelectedClick(Sender: TObject);
     procedure mniViewSetToDefaultClick(Sender: TObject);
+    procedure mniNavApplyLastScriptClick(Sender: TObject);
   protected
     BackHistory: IInterfaceList;
     ForwardHistory: IInterfaceList;
@@ -5686,6 +5688,21 @@ begin
   end;
 end;
 
+procedure TfrmMain.mniNavApplyLastScriptClick(Sender: TObject);
+var
+  LastUsedScript: String;
+  slScript: TStringList;
+begin
+  LastUsedScript := Settings.ReadString('View', 'LastUsedScript', '');
+  if FileExists(wbScriptsPath + LastUsedScript + '.pas') then try
+    slScript := TStringList.Create;
+    slScript.LoadFromFile(wbScriptsPath + LastUsedScript + '.pas');
+    ApplyScript(slScript.Text);
+  finally
+    FreeAndNil(slScript);
+  end;
+end;
+
 procedure TfrmMain.mniNavApplyScriptClick(Sender: TObject);
 var
   Scr: string;
@@ -10292,6 +10309,7 @@ var
   i                           : Integer;
   Nodes                       : TNodeArray;
   sl                          : TStringList;
+  LastUsedScript              : String;
 begin
   mniNavTest.Visible := DebugHook <> 0;
 
@@ -10357,7 +10375,14 @@ begin
   mniNavCleanMasters.Visible := mniNavAddMasters.Visible;
   mniNavBatchChangeReferencingRecords.Visible := mniNavAddMasters.Visible;
   mniNavApplyScript.Visible := mniNavCheckForErrors.Visible;
+  mniNavApplyLastScript.Visible := mniNavApplyScript.Visible;
   mniNavGenerateLOD.Visible := mniNavCompareTo.Visible and (wbGameMode in [gmTES4, gmFO3, gmFNV, gmTES5, gmSSE, gmFO4]);
+
+  LastUsedScript := Settings.ReadString('View', 'LastUsedScript', '');
+  if FileExists(wbScriptsPath + LastUsedScript + '.pas') then
+    mniNavApplyLastScript.Caption := 'Apply Last Script < ' + LastUsedScript + ' >'
+  else
+    mniNavApplyLastScript.Visible := False;
 
   mniNavAdd.Clear;
   pmuNavAdd.Items.Clear;


### PR DESCRIPTION
## Added feature

Apply Last Script executes the last used script. This feature can be accessed in two ways:

- The user can click Apply Last Script in the context menu under Apply Script.
- The user can press the F9 key to run the last used script.

When a script is executed, the Apply Last Script item caption is updated to display that script's name.

## Improved performance

### Old behavior

When the Apply Script window is opened, the scripts dropdown is immediately populated. When the dropdown needs to be populated with a lot of scripts, the opening of the window can be slow.

### New behavior

When the Apply Script window is opened, the scripts dropdown is immediately populated with the last used script. When the scripts dropdown is activated, the dropdown is populated.