### PR TITLE
Update LOOT masterlist entry template

### DIFF
--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -8615,7 +8615,7 @@ begin
 end;
 
 function TfrmMain.LOManagersDirtyInfo(aInfo: TPluginDirtyInfo): string;
-// LOOT entry example
+// LOOT dirty entry example
 {
   - name: 'DLCRobot.esm'
     dirty:
@@ -8625,6 +8625,13 @@ function TfrmMain.LOManagersDirtyInfo(aInfo: TPluginDirtyInfo): string;
         itm: 45
         udr: 38
         nav: 1
+}
+// LOOT clean entry example
+{
+  - name: 'BetterSettlers.esp'
+    clean:
+      - crc: 0x6A5FC68B
+        util: 'FO4Edit v3.2'
 }
 // BOSS entry example
 {
@@ -8654,6 +8661,13 @@ begin
     if aInfo.ITM <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'itm: %d', [aInfo.ITM]);
     if aInfo.UDR <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'udr: %d', [aInfo.UDR]);
     if aInfo.NAV <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'nav: %d', [aInfo.NAV]);
+  end
+  else if (aInfo.ITM = 0) and (aInfo.UDR = 0) and (aInfo.NAV = 0) then begin
+    Result := Result + CRLF + 'LOOT Masterlist Entry';
+    Result := Result + CRLF + Format(StringOfChar(' ', 2) + '- name: ''%s''', [aInfo.Plugin]);
+    Result := Result + CRLF + StringOfChar(' ', 4) + 'clean:';
+    Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'crc: 0x%s', [IntToHex(aInfo.CRC32, 8)]);
+    Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'util: %sEdit v%s', [wbAppName, VersionString]);
   end;
   if Result <> '' then
     Result := Result + CRLF;

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -8617,12 +8617,13 @@ end;
 function TfrmMain.LOManagersDirtyInfo(aInfo: TPluginDirtyInfo): string;
 // LOOT entry example
 {
-  - name: 'UDO.esp'
+  - name: 'DLCRobot.esm'
     dirty:
-      - crc: 0xd7d3445d
-        util: *dirtyUtil
-        itm: 15
-        udr: 4448
+      - <<: *dirtyPlugin
+        crc: 0xD69027EA
+        util: 'FO4Edit v3.2.1'
+        itm: 45
+        udr: 38
         nav: 1
 }
 // BOSS entry example
@@ -8647,8 +8648,9 @@ begin
     Result := Result + CRLF + 'LOOT Masterlist Entry';
     Result := Result + CRLF + Format(StringOfChar(' ', 2) + '- name: ''%s''', [aInfo.Plugin]);
     Result := Result + CRLF + StringOfChar(' ', 4) + 'dirty:';
-    Result := Result + CRLF + Format(StringOfChar(' ', 6) + '- crc: 0x%s', [LowerCase(IntToHex(aInfo.CRC32, 8))]);
-    Result := Result + CRLF + StringOfChar(' ', 8) + 'util: *dirtyUtil';
+    Result := Result + CRLF + StringOfChar(' ', 6) + '- <<: *dirtyPlugin';
+    Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'crc: 0x%s', [IntToHex(aInfo.CRC32, 8)]);
+    Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'util: %sEdit v%s', [wbAppName, VersionString]);
     if aInfo.ITM <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'itm: %d', [aInfo.ITM]);
     if aInfo.UDR <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'udr: %d', [aInfo.UDR]);
     if aInfo.NAV <> 0 then Result := Result + CRLF + Format(StringOfChar(' ', 8) + 'nav: %d', [aInfo.NAV]);


### PR DESCRIPTION
This PR aims to both update the `dirty` template to current LOOT masterlist standards/practices as well as add an additional template for `clean` plugins.

These commits were created in Linux and I don't think I have a way of compiling the program to test how/if they work. The code was mostly based on surrounding code, so I think it should work as intended, but I'm not so sure about the `VersionString` from `wbInterface.pas`.

I'm also not sure about the logic for showing the `BOSS/LOOT Cleaning Report` menu entry. It seems to check if `Length(PluginDirtyInfos) <> 0`, and I'm not sure this is true for clean plugins or only for plugins with (found) ITMs/UDRs/NAVs.

Anyway, if someone can test this out, that'd be great, and I'm happy to update the PR with any changes you want implemented. :)