### PR TITLE
Ignore unused elements in FO4 definitions

### DIFF
--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -6589,7 +6589,7 @@ begin
 
   wbScriptPropertyObject := wbUnion('Object Union', wbScriptObjFormatDecider, [
     wbStructSK([1], 'Object v2', [
-      wbInteger('Unused', itU16, nil, cpIgnore),
+      wbInteger('Unused', itU16, nil, cpIgnore, False, wbNeverShow),
       wbInteger('Alias', itS16, wbScriptObjectAliasToStr, wbStrToAlias).SetDefaultEditValue('None'),
       wbFormID('FormID')
     ], [2, 1, 0]),
@@ -6754,7 +6754,7 @@ begin
     wbArrayS('Fragments',
       wbStructSK([0], 'Fragment', [
         wbInteger('Fragment Index', itU16),
-        wbInteger('Unknown', itS16),
+        wbInteger('Unused', itS16, nil, cpIgnore, False, wbNeverShow),
         wbInteger('Unknown', itS8),
         wbLenString('scriptName', 2),
         wbLenString('fragmentName', 2)
@@ -8830,7 +8830,7 @@ begin
       wbInteger('Armor Rating', itU16),
       wbInteger('Base Addon Index', itU16),
       wbInteger('Stagger Rating', itU8, wbStaggerEnum),
-      wbUnknown
+      wbUnknown(cpIgnore, False, wbNeverShow, nil)
     ]),
     wbArrayS(DAMA, 'Resistances', wbStructSK([0], 'Resistance', [
       wbFormIDCk('Damage Type', [DMGT]),


### PR DESCRIPTION
- ARMO - FNAM\Unknown: Always an empty byte array.
- VMAD - Object v2: Unused element really is unused.
- VMAD - Script Fragment: First unknown element is always 0.

Note: The second unknown element in VMAD Script Fragments actually controls whether the fragment is enabled or disabled, but I have no idea what to call it since the toggle isn't available in the CK.