### PR TITLE
Add sort boolean to AddMasterIfMissing and expose AddMasters to scripts

### DIFF
--- a/Edit Scripts/xEditAPI.pas
+++ b/Edit Scripts/xEditAPI.pas
@@ -316,8 +316,10 @@ procedure SetElementNativeValues(aeContainer: IwbContainer; asPath: string; avVa
 // IwbFile Functions
 // ********************************************************************
 
-/// <summary>Adds the specified file as a master for aeFile, if it isn't already a master.</summary>
-procedure AddMasterIfMissing(aeFile: IwbFile; asMasterFilename: string);
+/// <summary>Adds the list of masters in aMasters to aeFile. If sorting is desired an explicit call to SortMasters is necessary.</summary>
+procedure AddMasters(aeFile: IwbFile; aMasters: TStrings);
+/// <summary>Adds the specified file as a master for aeFile, if it isn't already a master. If SortMasters is true (the default) all masters will be sorted if any were added.</summary>
+procedure AddMasterIfMissing(aeFile: IwbFile; asMasterFilename: string; aSortMasters: Boolean = True);
 /// <summary>Creates a new, empty plugin in the game's plugin folder (Data) and adds it to the end of the plugins list.</summary>
 /// <param name="asFileName">Name of the plugin.</param>
 /// <returns>The reference to the newly created plugin as a IwbFile</returns>
@@ -968,7 +970,11 @@ end;
 // IwbFile Functions
 // ********************************************************************
 
-procedure AddMasterIfMissing(aeFile: IwbFile; asMasterFilename: string);
+procedure AddMasters(aeFile: IwbFile; aMasters: TStrings);
+begin
+end;
+
+procedure AddMasterIfMissing(aeFile: IwbFile; asMasterFilename: string; aSortMasters: Boolean = True);
 begin
 end;
 

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -707,7 +707,7 @@ type
     function FileFileIDtoLoadOrderFileID(aFileID: TwbFileID): TwbFileID;
 
     procedure AddMasters(aMasters: TStrings);
-    procedure AddMasterIfMissing(const aMaster: string);
+    procedure AddMasterIfMissing(const aMaster: string; aSortMasters: Boolean = True);
     procedure SortMasters;
     procedure CleanMasters;
 
@@ -2111,7 +2111,7 @@ begin
   UpdateModuleMasters;
 end;
 
-procedure TwbFile.AddMasterIfMissing(const aMaster: string);
+procedure TwbFile.AddMasterIfMissing(const aMaster: string; aSortMasters: Boolean = True);
 var
   i       : Integer;
   Masters : TStringList;
@@ -2123,7 +2123,8 @@ begin
   try
     Masters.Add(aMaster);
     AddMasters(Masters);
-    SortMasters;
+    if aSortMasters then
+      SortMasters;
   finally
     Masters.Free;
   end;

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -1129,7 +1129,7 @@ type
 
     procedure GetMasters(aMasters: TStrings);
     procedure AddMasters(aMasters: TStrings);
-    procedure AddMasterIfMissing(const aMaster: string);
+    procedure AddMasterIfMissing(const aMaster: string; aSortMasters: Boolean = True);
     procedure SortMasters;
     procedure CleanMasters;
 

--- a/wbScriptAdapter.pas
+++ b/wbScriptAdapter.pas
@@ -1451,12 +1451,26 @@ begin
     Value := _File.RecordByEditorID[string(Args.Values[1])];
 end;
 
+procedure IwbFile_AddMasters(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  _File: IwbFile;
+begin
+  if Supports(IInterface(Args.Values[0]), IwbFile, _File) then
+    _File.AddMasters(TStrings(V2O(Args.Values[1])));
+end;
+
 procedure IwbFile_AddMasterIfMissing(var Value: Variant; Args: TJvInterpreterArgs);
 var
   _File: IwbFile;
 begin
   if Supports(IInterface(Args.Values[0]), IwbFile, _File) then
-    _File.AddMasterIfMissing(string(Args.Values[1]));
+    case Args.Count of
+    0, 1: JvInterpreterError(ieNotEnoughParams, -1);
+    3: _File.AddMasterIfMissing(string(Args.Values[1]), Boolean(Args.Values[2]));
+    2: _File.AddMasterIfMissing(string(Args.Values[1]));
+    else
+     JvInterpreterError(ieTooManyParams, -1);
+    end;
 end;
 
 procedure IwbFile_HasMaster(var Value: Variant; Args: TJvInterpreterArgs);
@@ -2014,7 +2028,8 @@ begin
     AddFunction(cUnit, 'GroupBySignature', IwbFile_GroupBySignature, 2, [varEmpty, varString], varEmpty);
     AddFunction(cUnit, 'RecordByFormID', IwbFile_RecordByFormID, 3, [varEmpty, varInteger, varBoolean], varEmpty);
     AddFunction(cUnit, 'RecordByEditorID', IwbFile_RecordByEditorID, 2, [varEmpty, varString], varEmpty);
-    AddFunction(cUnit, 'AddMasterIfMissing', IwbFile_AddMasterIfMissing, 2, [varEmpty, varString], varEmpty);
+    AddFunction(cUnit, 'AddMasters', IwbFile_AddMasters, 2, [varEmpty, varEmpty], varEmpty);
+    AddFunction(cUnit, 'AddMasterIfMissing', IwbFile_AddMasterIfMissing, -1, [varEmpty, varString], varEmpty);
     AddFunction(cUnit, 'HasMaster', IwbFile_HasMaster, 2, [varEmpty, varString], varEmpty);
     AddFunction(cUnit, 'HasGroup', IwbFile_HasGroup, 2, [varEmpty, varString], varEmpty);
     AddFunction(cUnit, 'LoadOrderFormIDtoFileFormID', IwbFile_LoadOrderFormIDtoFileFormID, 2, [varEmpty, varEmpty], varEmpty);


### PR DESCRIPTION
* AddMasterIfMissing: Add an optional SortMasters argument (which
  defaults to true) so that calling code can add control the sorting
  behavior. This is useful in cases where a set of masters is being
  added one after another without having to incur the cost of a
  implicit SortMasters on each call.

* AddMasters: Expose API function via the scripting interface for
  callers that want to add a list of masters directly.