### PR TITLE
Add -scriptargs command line option handling

### DIFF
--- a/Edit Scripts/xEditAPI.pas
+++ b/Edit Scripts/xEditAPI.pas
@@ -133,6 +133,9 @@ function ProgramPath:	String;
 /// <summary>Provides the file path to Tes5Edit's 'Edit Scripts' folder as a String.</summary>
 /// <remarks>NOTE If launching TES5Edit via a .tes5pas file, ScriptsPath will change to the directory where the .te5pas file is located. (therefore if your script has any .pas file it is grabbing functions from, they also need to be in the that same directory.)</remarks>
 function ScriptsPath:	String;
+/// <summary>Provides the argument passed to the -scriptargs:"<args>" command line option as a String.</summary>
+/// <remarks>NOTE: If one needs to pass comma separated or other formatted data they should pass it as a single string and then parse the string returned from ScriptArgs in a script's Initialize function.</remarks>
+function ScriptArgs:	String;
 /// <summary>Provides the number of loaded files in your current TES5Edit session</summary>
 /// <remarks>NOTE: "Skyrim.Hardcoded.keep.this..." (aka. Skyrim.exe) is considered a file and is reflected in this variable.</remarks>
 function FileCount:	Integer;
@@ -575,6 +578,11 @@ begin
 end;
 
 function ScriptsPath:	String;
+begin
+  Result := '';
+end;
+
+function ScriptArgs:	String;
 begin
   Result := '';
 end;

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -17500,6 +17500,11 @@ begin
     Value := wbScriptsPath;
     Done := True;
   end
+  else if (SameText(Identifier, 'ScriptArgs') and (Args.Count = 0)) or
+     (SameText(Identifier, 'wbScriptArgs') and (Args.Count = 0)) then begin
+    Value := wbScriptArgs;
+    Done := True;
+  end
   else if (SameText(Identifier, 'wbDataPath') and (Args.Count = 0)) or
      (SameText(Identifier, 'DataPath') and (Args.Count = 0)) then begin
     Value := wbDataPath;

--- a/wbInit.pas
+++ b/wbInit.pas
@@ -857,6 +857,13 @@ begin
     wbSimpleRecords := False;
   end;
 
+  // Generic arguments usable by scripts for their own decision logic.
+  // The argument is parsed as a literal string to give scripts the
+  // option of parsing it how they see fit as it may not be a safe
+  // assumption to comma-split it by default.
+  if wbFindCmdLineParam('scriptargs', s) then
+    wbScriptArgs := s;
+
   // definitions
   case wbGameMode of
     gmFNV: case wbToolSource of

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -133,6 +133,7 @@ var
   wbReportModGroups        : Boolean  = False;
   wbRequireCtrlForDblClick : Boolean  = False;
   wbFocusAddedElement      : Boolean  = True;
+  wbScriptArgs             : String;
 
   wbGlobalModifedGeneration : UInt64;
 


### PR DESCRIPTION
* Permit outside string data to be passed to the scripting environment
  via -scriptargs:"\<args\>". The string passed is accessible via the
  `ScriptArgs` function which simply returns the string parsed from the
  command line. If the string needs to be CSV parsed or otherwise has
  it's own formatting then the calling script should handle that within
  an Initialize or other function.