### PR TITLE
Swap Fallout 76 wbGameName2 for wbGameNameReg

### DIFF
--- a/wbInit.pas
+++ b/wbInit.pas
@@ -745,7 +745,7 @@ begin
     wbGameMode := gmFO76;
     wbAppName := 'FO76';
     wbGameName := 'Fallout76';
-    wbGameName2 := 'Fallout 76';
+    wbGameNameReg := 'Fallout 76';
     wbGameMasterEsm := 'SeventySix.esm';
     wbLanguage := 'En';
     wbArchiveExtension := '.ba2';

--- a/wbInit.pas
+++ b/wbInit.pas
@@ -415,7 +415,11 @@ begin
       ShowMessage('Fatal: Could not determine my documents folder');
       Exit;
     end;
-    wbMyGamesTheGamePath := wbMyProfileName + 'My Games\' + wbGameName2 + '\';
+    
+    if wbGameMode in [gmFO76] then
+      wbMyGamesTheGamePath := wbMyProfileName + 'My Games\' + wbGameNameReg + '\'
+    else
+      wbMyGamesTheGamePath := wbMyProfileName + 'My Games\' + wbGameName2 + '\';
 
     if wbGameMode in [gmFO3, gmFNV] then
       wbTheGameIniFileName := wbMyGamesTheGamePath + 'Fallout.ini'


### PR DESCRIPTION
Fallout 76 creates a "Fallout76" folder in %LOCALAPPDATA%, not a "Fallout 76" folder, but we still need the title space when searching the registry for the install path. This does that.