### PR TITLE
Added StripEmptyMasters command line switch

### DIFF
--- a/wbInit.pas
+++ b/wbInit.pas
@@ -938,6 +938,9 @@ begin
   if wbIKnowWhatImDoing and FindCmdLineSwitch('AllowMasterFilesEdit') then
     wbAllowMasterFilesEdit := True;
 
+  if wbIKnowWhatImDoing and FindCmdLineSwitch('StripEmptyMasters') then
+    wbStripEmptyMasters := True;
+
   if wbToolMode = tmEdit then begin
     if FindCmdLineSwitch('quickshowconflicts') or ExeName.Contains('quickshowconflicts') or ExeName.Contains('qsc') then
       wbQuickShowConflicts := True;


### PR DESCRIPTION
Added a `StripEmptyMasters` command line switch for the feature El added in Aug 2018 to allow xEdit to load plugins with empty string master subrecords.

The feature fixes the issue discussed in the #archive-empty-string-masters situation room. The new switch requires the `IKnowWhatImDoing` switch.