### PR TITLE
The Great Collapse - First Pass - Bonus Round

### DIFF
--- a/frmOptionsForm.dfm
+++ b/frmOptionsForm.dfm
@@ -238,7 +238,7 @@ object frmOptions: TfrmOptions
       object cbCollapseConditions: TCheckBox
         Left = 16
         Top = 62
-        Width = 220
+        Width = 89
         Height = 17
         Caption = 'Conditions'
         TabOrder = 2
@@ -248,7 +248,7 @@ object frmOptions: TfrmOptions
         Top = 62
         Width = 220
         Height = 17
-        Caption = 'Faction Relations (except TES4)'
+        Caption = 'Faction Relations'
         TabOrder = 3
       end
       object cbCollapseModels: TCheckBox
@@ -306,6 +306,14 @@ object frmOptions: TfrmOptions
         Height = 17
         Caption = 'Race Equip Slots (only FO4 and FO76)'
         TabOrder = 10
+      end
+      object cbCollapseFactions: TCheckBox
+        Left = 138
+        Top = 62
+        Width = 91
+        Height = 17
+        Caption = 'Factions'
+        TabOrder = 11
       end
     end
     object tsCleaning: TTabSheet

--- a/frmOptionsForm.pas
+++ b/frmOptionsForm.pas
@@ -94,6 +94,7 @@ type
     cbCollapseLeveledItems: TCheckBox;
     cbCollapseObjectProperties: TCheckBox;
     cbCollapseEquipSlots: TCheckBox;
+    cbCollapseFactions: TCheckBox;
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormCreate(Sender: TObject);
     procedure cbConflictThisChange(Sender: TObject);

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -5154,6 +5154,7 @@ begin
   wbCollapseRecordHeader := Settings.ReadBool('Options', 'CollapseRecordHeader', wbCollapseRecordHeader);
   wbCollapseObjectBounds := Settings.ReadBool('Options', 'CollapseObjectBounds', wbCollapseObjectBounds);
   wbCollapseModels := Settings.ReadBool('Options', 'CollapseModels', wbCollapseModels);
+  wbCollapseFactions := Settings.ReadBool('Options', 'CollapseFactions', wbCollapseFactions);
   wbCollapseFactionRelations := Settings.ReadBool('Options', 'CollapseFactionRelations', wbCollapseFactionRelations);
   wbCollapseItems := Settings.ReadBool('Options', 'CollapseItems', wbCollapseItems);
   wbCollapseLeveledItems := Settings.ReadBool('Options', 'CollapseLeveledItems', wbCollapseLeveledItems);
@@ -13109,6 +13110,7 @@ begin
     cbCollapseRecordHeader.Checked := wbCollapseRecordHeader;
     cbCollapseObjectBounds.Checked := wbCollapseObjectBounds;
     cbCollapseModels.Checked := wbCollapseModels;
+    cbCollapseFactions.Checked := wbCollapseFactions;
     cbCollapseFactionRelations.Checked := wbCollapseFactionRelations;
     cbCollapseItems.Checked := wbCollapseItems;
     cbCollapseLeveledItems.Checked := wbCollapseLeveledItems;
@@ -13175,6 +13177,7 @@ begin
     wbCollapseRecordHeader := cbCollapseRecordHeader.Checked;
     wbCollapseObjectBounds := cbCollapseObjectBounds.Checked;
     wbCollapseModels := cbCollapseModels.Checked;
+    wbCollapseFactions := cbCollapseFactions.Checked;
     wbCollapseFactionRelations := cbCollapseFactionRelations.Checked;
     wbCollapseItems := cbCollapseItems.Checked;
     wbCollapseLeveledItems := cbCollapseLeveledItems.Checked;
@@ -13240,6 +13243,7 @@ begin
     Settings.WriteBool('Options', 'CollapseRecordHeader', wbCollapseRecordHeader);
     Settings.WriteBool('Options', 'CollapseObjectBounds', wbCollapseObjectBounds);
     Settings.WriteBool('Options', 'CollapseModels', wbCollapseModels);
+    Settings.WriteBool('Options', 'CollapseFactions', wbCollapseFactions);
     Settings.WriteBool('Options', 'CollapseFactionRelations', wbCollapseFactionRelations);
     Settings.WriteBool('Options', 'CollapseItems', wbCollapseItems);
     Settings.WriteBool('Options', 'CollapseLeveledItems', wbCollapseLeveledItems);

--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -400,45 +400,68 @@ end;
 
 procedure wbFactionToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 var
-  Faction: IwbContainerElementRef;
+  Container: IwbContainerElementRef;
   FormID, Rank: IwbElement;
   MainRecord: IwbMainRecord;
+  NativeRank: integer;
 begin
   if aType <> ctToStr then
     Exit;
 
-  if not Supports(aElement, IwbContainerElementRef, Faction) then
+  if not Supports(aElement, IwbContainerElementRef, Container) then
     Exit;
 
-  if Faction.Collapsed <> tbTrue then
+  if Container.Collapsed <> tbTrue then
     Exit;
 
-  FormID := Faction.Elements[0];
+  FormID := Container.Elements[0];
   if not Assigned(FormID) then
     Exit;
 
   if not Supports(FormID.LinksTo, IwbMainRecord, MainRecord) then
     Exit;
 
-  Rank := Faction.Elements[1];
+  Rank := Container.Elements[1];
+  NativeRank := Rank.NativeValue;
 
-  aValue := MainRecord.ShortName + ' {Rank: ' + Rank.Value + '}';
+  aValue := MainRecord.ShortName + ' {Rank: ' + IntToStr(NativeRank) + '}';
 end;
 
 procedure wbFactionRelationToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 var
-  Relation: IwbContainerElementRef;
+  Container: IwbContainerElementRef;
+  FormID, Rank, CombatReaction: IwbElement;
+  MainRecord: IwbMainRecord;
+  RankMod: string;
+  NativeRank: integer;
 begin
   if aType <> ctToStr then
     Exit;
 
-  if not Supports(aElement, IwbContainerElementRef, Relation) then
+  if not Supports(aElement, IwbContainerElementRef, Container) then
     Exit;
 
-  if Relation.Collapsed <> tbTrue then
+  if Container.Collapsed <> tbTrue then
     Exit;
 
-  aValue := Relation.Elements[2].Value + ' ' + Relation.Elements[0].Value;
+  FormID := Container.Elements[0];
+  if not Assigned(FormID) then
+    Exit;
+
+  if not Supports(FormID.LinksTo, IwbMainRecord, MainRecord) then
+    Exit;
+
+  Rank := Container.Elements[1];
+  NativeRank := Rank.NativeValue;
+
+  if wbGameMode = gmTES4 then begin
+    if NativeRank > 0 then RankMod := '+' else RankMod := '-';
+    aValue := RankMod + IntToStr(NativeRank) + ' ' + MainRecord.ShortName;
+    Exit;
+  end;
+
+  CombatReaction := Container.Elements[2];
+  aValue := CombatReaction.Value + ' ' + MainRecord.ShortName;
 end;
 
 procedure wbModelToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);

--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -455,8 +455,10 @@ begin
   NativeRank := Rank.NativeValue;
 
   if wbGameMode = gmTES4 then begin
-    if NativeRank > 0 then RankMod := '+' else RankMod := '-';
-    aValue := RankMod + IntToStr(NativeRank) + ' ' + MainRecord.ShortName;
+    if NativeRank >= 0 then
+      aValue := '+' + IntToStr(NativeRank) + ' ' + MainRecord.ShortName
+    else
+      aValue := IntToStr(NativeRank) + ' ' + MainRecord.ShortName;
     Exit;
   end;
 

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -310,7 +310,7 @@ var
   wbCSDTs: IwbSubRecordArrayDef;
   wbFULL: IwbSubRecordDef;
   wbFULLReq: IwbSubRecordDef;
-  wbXNAM: IwbSubRecordDef;
+  wbXNAM: IwbRecordMemberDef;
   wbXNAMs: IwbSubRecordArrayDef;
   wbDESC: IwbSubRecordDef;
   wbXSCL: IwbSubRecordDef;
@@ -3156,7 +3156,7 @@ begin
     wbStructSK(XNAM, [0], 'Relation', [
       wbFormIDCkNoReach('Faction', [FACT, RACE]),
       wbInteger('Modifier', itS32)
-    ]);
+    ]).SetToStr(wbFactionRelationToStr).IncludeFlag(dfCollapsed, wbCollapseFactionRelations);
 
   wbXNAMs := wbRArrayS('Relations', wbXNAM);
 

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -344,6 +344,10 @@ var
   wbLeveledListEntryCreature: IwbRecordMemberDef;
   wbLeveledListEntryItem: IwbRecordMemberDef;
   wbLeveledListEntrySpell: IwbRecordMemberDef;
+  wbMaleBipedModel: IwbRecordMemberDef;
+  wbMaleWorldModel: IwbRecordMemberDef;
+  wbFemaleBipedModel: IwbRecordMemberDef;
+  wbFemaleWorldModel: IwbRecordMemberDef;
 
 function wbClmtMoonsPhaseLength(aInt: Int64; const aElement: IwbElement; aType: TwbCallbackType): string;
 var
@@ -2011,7 +2015,7 @@ begin
     {0x00008000}'Visible when distant',
     {0x00010000}'',
     {0x00020000}'Dangerous / Off limits (Interior cell)',
-    {0x00040000}'Compressed ',
+    {0x00040000}'Compressed',
     {0x00080000}'Can''t wait'
   ]));
 
@@ -2442,6 +2446,34 @@ begin
     ], cpNormal, True)
   ]);
 
+  wbMaleBipedModel :=
+    wbRStruct('Male biped model', [
+      wbString(MODL, 'Model FileName'),
+      wbFloat(MODB, 'Bound Radius', cpBenign),
+      wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
+    ], []).SetToStr(wbModelToStr).IncludeFlag(dfCollapsed, wbCollapseModels);
+
+  wbMaleWorldModel :=
+    wbRStruct('Male world model', [
+      wbString(MOD2, 'Model FileName'),
+      wbFloat(MO2B, 'Bound Radius', cpBenign),
+      wbByteArray(MO2T, 'Texture Files Hashes', 0, cpIgnore)
+    ], []).SetToStr(wbModelToStr).IncludeFlag(dfCollapsed, wbCollapseModels);
+
+  wbFemaleBipedModel :=
+    wbRStruct('Female biped model', [
+      wbString(MOD3, 'Model FileName'),
+      wbFloat(MO3B, 'Bound Radius', cpBenign),
+      wbByteArray(MO3T, 'Texture Files Hashes', 0, cpIgnore)
+    ], []).SetToStr(wbModelToStr).IncludeFlag(dfCollapsed, wbCollapseModels);
+
+  wbFemaleWorldModel :=
+    wbRStruct('Female world model', [
+      wbString(MOD4, 'Model FileName'),
+      wbFloat(MO4B, 'Bound Radius', cpBenign),
+      wbByteArray(MO4T, 'Texture Files Hashes', 0, cpIgnore)
+    ], []).SetToStr(wbModelToStr).IncludeFlag(dfCollapsed, wbCollapseModels);
+
   wbRecord(ARMO, 'Armor', [
     wbEDID,
     wbFULL,
@@ -2479,27 +2511,11 @@ begin
       ])),
       wbByteArray('Unused', 1)
     ], cpNormal, True),
-    wbRStruct('Male biped model', [
-      wbString(MODL, 'Model FileName'),
-      wbFloat(MODB, 'Bound Radius', cpBenign),
-      wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
-    wbRStruct('Male world model', [
-      wbString(MOD2, 'Model FileName'),
-      wbFloat(MO2B, 'Bound Radius', cpBenign),
-      wbByteArray(MO2T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
+    wbMaleBipedModel,
+    wbMaleWorldModel,
     wbString(ICON, 'Male icon FileName'),
-    wbRStruct('Female biped model', [
-      wbString(MOD3, 'Model FileName'),
-      wbFloat(MO3B, 'Bound Radius', cpBenign),
-      wbByteArray(MO3T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
-    wbRStruct('Female world model', [
-      wbString(MOD4, 'Model FileName'),
-      wbFloat(MO4B, 'Bound Radius', cpBenign),
-      wbByteArray(MO4T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
+    wbFemaleBipedModel,
+    wbFemaleWorldModel,
     wbString(ICO2, 'Female icon FileName'),
     wbStruct(DATA, '', [
       wbInteger('Armor', itU16, wbDiv(100)),
@@ -2693,27 +2709,11 @@ begin
       ])),
       wbByteArray('Unused', 1)
     ], cpNormal, True),
-    wbRStruct('Male biped model', [
-      wbString(MODL, 'Model FileName'),
-      wbFloat(MODB, 'Bound Radius', cpBenign),
-      wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
-    wbRStruct('Male world model', [
-      wbString(MOD2, 'Model FileName'),
-      wbFloat(MO2B, 'Bound Radius', cpBenign),
-      wbByteArray(MO2T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
+    wbMaleBipedModel,
+    wbMaleWorldModel,
     wbString(ICON, 'Male icon FileName'),
-    wbRStruct('Female biped model', [
-      wbString(MOD3, 'Model FileName'),
-      wbFloat(MO3B, 'Bound Radius', cpBenign),
-      wbByteArray(MO3T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
-    wbRStruct('Female world model', [
-      wbString(MOD4, 'Model FileName'),
-      wbFloat(MO4B, 'Bound Radius', cpBenign),
-      wbByteArray(MO4T, 'Texture Files Hashes', 0, cpIgnore)
-    ], []),
+    wbFemaleBipedModel,
+    wbFemaleWorldModel,
     wbString(ICO2, 'Female icon FileName'),
     wbStruct(DATA, '', [
       wbInteger('Value', itU32),


### PR DESCRIPTION
- added compact display for collapsed Biped and World Models (TES4)
- added compact display for collapsed Faction Relations (TES4)
- added missing Collapse Factions checkbox to View Options
- removed TES4 exclusion from Collapse Faction Relations checkbox label in View Options
- fixed trailing space in Compressed flag name (TES4)
- fixed double negative modifier issue in collapsed Faction Relations (TES4)