### PR TITLE
The Great Collapse - Second Pass, Part 1

### DIFF
--- a/frmOptionsForm.dfm
+++ b/frmOptionsForm.dfm
@@ -219,6 +219,19 @@ object frmOptions: TfrmOptions
         Font.Style = [fsBold]
         ParentFont = False
       end
+      object lblTypesToCollapse: TLabel
+        Left = 16
+        Top = 231
+        Width = 263
+        Height = 13
+        Caption = 'Types to Collapse by Default (requires restart)'
+        Font.Charset = DEFAULT_CHARSET
+        Font.Color = clWindowText
+        Font.Height = -11
+        Font.Name = 'Tahoma'
+        Font.Style = [fsBold]
+        ParentFont = False
+      end
       object cbCollapseRecordHeader: TCheckBox
         Left = 16
         Top = 39
@@ -314,6 +327,22 @@ object frmOptions: TfrmOptions
         Height = 17
         Caption = 'Factions'
         TabOrder = 11
+      end
+      object cbCollapseRGBA: TCheckBox
+        Left = 16
+        Top = 255
+        Width = 213
+        Height = 17
+        Caption = 'Colors (RGB/A)'
+        TabOrder = 12
+      end
+      object cbCollapseVec3: TCheckBox
+        Left = 235
+        Top = 255
+        Width = 213
+        Height = 17
+        Caption = 'Vector3 (XYZ)'
+        TabOrder = 13
       end
     end
     object tsCleaning: TTabSheet

--- a/frmOptionsForm.dfm
+++ b/frmOptionsForm.dfm
@@ -723,7 +723,7 @@ object frmOptions: TfrmOptions
           'he end'
         Caption = 
           'Show values of flags and enumerations (requires restart, interfe' +
-          'rs with scripts)'
+          'res with scripts)'
         TabOrder = 1
       end
       object cbSortINFO: TCheckBox

--- a/frmOptionsForm.pas
+++ b/frmOptionsForm.pas
@@ -95,6 +95,9 @@ type
     cbCollapseObjectProperties: TCheckBox;
     cbCollapseEquipSlots: TCheckBox;
     cbCollapseFactions: TCheckBox;
+    lblTypesToCollapse: TLabel;
+    cbCollapseRGBA: TCheckBox;
+    cbCollapseVec3: TCheckBox;
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormCreate(Sender: TObject);
     procedure cbConflictThisChange(Sender: TObject);

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -5163,6 +5163,8 @@ begin
   wbCollapseScriptProperties := Settings.ReadBool('Options', 'CollapseScriptProperties', wbCollapseScriptProperties);
   wbCollapseConditions := Settings.ReadBool('Options', 'CollapseConditions', wbCollapseConditions);
   wbCollapseBenignArray := Settings.ReadBool('Options', 'CollapseBenignArray', wbCollapseBenignArray);
+  wbCollapseRGBA := Settings.ReadBool('Options', 'CollapseRGBA', wbCollapseRGBA);
+  wbCollapseVec3 := Settings.ReadBool('Options', 'CollapseVec3', wbCollapseVec3);
   wbShrinkButtons := Settings.ReadBool('Options', 'ShrinkButtons', wbShrinkButtons);
   //wbIKnowWhatImDoing := Settings.ReadBool('Options', 'IKnowWhatImDoing', wbIKnowWhatImDoing);
   wbUDRSetXESP := Settings.ReadBool('Options', 'UDRSetXESP', wbUDRSetXESP);
@@ -13119,6 +13121,8 @@ begin
     cbCollapseScriptProperties.Checked := wbCollapseScriptProperties;
     cbCollapseConditions.Checked := wbCollapseConditions;
     cbCollapseBenignArray.Checked := wbCollapseBenignArray;
+    cbCollapseRGBA.Checked := wbCollapseRGBA;
+    cbCollapseVec3.Checked := wbCollapseVec3;
     cbShrinkButtons.Checked := wbShrinkButtons;
     edColumnWidth.Text := IntToStr(ColumnWidth);
     edRowHeight.Text := IntToStr(RowHeight);
@@ -13186,6 +13190,8 @@ begin
     wbCollapseScriptProperties := cbCollapseScriptProperties.Checked;
     wbCollapseConditions := cbCollapseConditions.Checked;
     wbCollapseBenignArray := cbCollapseBenignArray.Checked;
+    wbCollapseRGBA := cbCollapseRGBA.Checked;
+    wbCollapseVec3 := cbCollapseVec3.Checked;
     if (wbShrinkButtons <> cbShrinkButtons.Checked) then
       if cbShrinkButtons.Checked then ShrinkButtons else ExpandButtons;
     wbShrinkButtons := cbShrinkButtons.Checked;
@@ -13252,6 +13258,8 @@ begin
     Settings.WriteBool('Options', 'CollapseScriptProperties', wbCollapseScriptProperties);
     Settings.WriteBool('Options', 'CollapseConditions', wbCollapseConditions);
     Settings.WriteBool('Options', 'CollapseBenignArray', wbCollapseBenignArray);
+    Settings.WriteBool('Options', 'CollapseRGBA', wbCollapseRGBA);
+    Settings.WriteBool('Options', 'CollapseVec3', wbCollapseVec3);
     Settings.WriteBool('Options', 'ShrinkButtons', wbShrinkButtons);
     Settings.WriteInteger('Options', 'ColumnWidth', ColumnWidth);
     Settings.WriteInteger('Options', 'RowHeight', RowHeight);

--- a/wbDataFormatMisc.pas
+++ b/wbDataFormatMisc.pas
@@ -108,7 +108,7 @@ begin
   dfLODTreeBTT :=
     dfArray('Trees', dfStruct('Tree', [
       dfInteger('Type', dtU32),
-      dfArray('References', dfStruct('Refefence', [
+      dfArray('References', dfStruct('Reference', [
         dfFloat('X'),
         dfFloat('Y'),
         dfFloat('Z'),

--- a/wbDataFormatNif.pas
+++ b/wbDataFormatNif.pas
@@ -4856,7 +4856,7 @@ begin
     dfBytes('Unused 1', 4),
     wbBroadPhaseType('Broad Phase Type', 'BROAD_PHASE_ENTITY', []),
     dfBytes('Unused 2', 3),
-    wbhkWorldObjCinfoProperty('Cinfo Prpperty', [])
+    wbhkWorldObjCinfoProperty('Cinfo Property', [])
   ]), 'bhkSerializable', True);
 end;
 
@@ -5491,7 +5491,7 @@ begin
     dfFloat('Dimmer', '1.0'),
     wbColor3('Ambient Color', '#000000', []),
     wbColor3('Diffuse Color', '#000000', []),
-    wbColor3('Speculat Color', '#000000', [])
+    wbColor3('Specular Color', '#000000', [])
   ]), 'NiDynamicEffect', True);
 end;
 
@@ -7099,9 +7099,9 @@ begin
     dfArray('Particle Descriptions', dfStruct('Particle Descriptions', [
       wbVector3('Translation'),
       dfArray('Unknown Floats 1', dfFloat('Unknown Floats 1'), 3, '', [DF_OnGetEnabled, @EnBefore10401]),
-      dfFloat('Uknown Float 1', '0.9'),
-      dfFloat('Uknown Float 2', '0.9'),
-      dfFloat('Uknown Float 3', '3.0'),
+      dfFloat('Unknown Float 1', '0.9'),
+      dfFloat('Unknown Float 2', '0.9'),
+      dfFloat('Unknown Float 3', '3.0'),
       dfInteger('Unknown Int', dtS32)
     ]), 0, 'Num Vertices', [DF_OnGetEnabled, @NiPSysData_EnDescriptions]),
     wbBool('Has Rotation Speeds', [DF_OnGetEnabled, @EnSince20004]),

--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -31,9 +31,13 @@ uses
 
   procedure wbRecordHeaderToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
+  procedure wbRGBAToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
+
   procedure wbObjectPropertyToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
   procedure wbScriptPropertyToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
+
+  procedure wbVec3ToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
   /// <summary>Calls and returns wbGetScriptObjFormat. Used for VMAD parsing.</summary>
   function wbScriptObjFormatDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;

--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -370,6 +370,8 @@ begin
   if not Assigned(Faction.LinksTo) then
     Exit;
 
+  Rank := Container.Elements[1];
+
   aValue := Faction.Value;
 
   if Assigned(Rank) then

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -1,4 +1,4 @@
-{*******************************************************************************
+ï»¿{*******************************************************************************
 
      The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
@@ -653,10 +653,6 @@ var
   wbBPNDStruct: IwbSubRecordDef;
   wbTimeInterpolator: IwbStructDef;
   wbColorInterpolator: IwbStructDef;
-  wbFaction: IwbRecordMemberDef;
-  wbLeveledListEntryCreature: IwbRecordMemberDef;
-  wbLeveledListEntryNPC: IwbRecordMemberDef;
-  wbLeveledListEntryItem: IwbRecordMemberDef;
 
 function wbNVTREdgeToStr(aInt: Int64; const aElement: IwbElement; aType: TwbCallbackType): string;
 var
@@ -5458,6 +5454,8 @@ begin
 end;
 
 procedure DefineFNVb;
+var
+  wbEffect: IwbRecordMemberDef;
 begin
   wbMiscStatEnum :=
     wbEnum([
@@ -5781,20 +5779,18 @@ begin
   wbCTDAs := wbRArray('Conditions', wbCTDA);
   wbCTDAsReq := wbRArray('Conditions', wbCTDA, cpNormal, True);
 
-  wbEffects :=
-    wbRStructs('Effects','Effect', [
+  wbEffect :=
+    wbRStruct('Effect', [
       wbEFID,
       wbEFIT,
       wbCTDAs
     ], []);
 
-  wbEffectsReq :=
-    wbRStructs('Effects','Effect', [
-      wbEFID,
-      wbEFIT,
-      wbCTDAs
-    ], [], cpNormal, True);
+  wbEffects :=
+    wbRArray('Effects', wbEffect);
 
+  wbEffectsReq :=
+    wbRArray('Effects', wbEffect, cpNormal, True);
 
   wbRecord(ALCH, 'Ingestible', [
     wbEDIDReq,
@@ -6151,6 +6147,8 @@ begin
 end;
 
 procedure DefineFNVc;
+var
+  wbFaction: IwbRecordMemberDef;
 begin
   wbRecord(CLMT, 'Climate', [
     wbEDIDReq,
@@ -6585,6 +6583,8 @@ begin
 end;
 
 procedure DefineFNVd;
+var
+  wbStaticPart: IwbRecordMemberDef;
 begin
   wbRecord(CSTY, 'Combat Style', [
     wbEDIDReq,
@@ -7189,11 +7189,8 @@ begin
     )
   ]);
 
-  wbRecord(SCOL, 'Static Collection', [
-    wbEDIDReq,
-    wbOBNDReq,
-    wbMODLReq,
-    wbRStructs('Parts', 'Part', [
+  wbStaticPart :=
+    wbRStruct('Part', [
       wbFormIDCk(ONAM, 'Static', [STAT]),
       wbArrayS(DATA, 'Placements', wbStruct('Placement', [
         wbStruct('Position', [
@@ -7208,7 +7205,13 @@ begin
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(SCOL, 'Static Collection', [
+    wbEDIDReq,
+    wbOBNDReq,
+    wbMODLReq,
+    wbRArray('Parts', wbStaticPart)
   ]);
 
   wbRecord(MSTT, 'Moveable Static', [
@@ -7311,6 +7314,12 @@ begin
 end;
 
 procedure DefineFNVe;
+var
+  wbDebrisModel: IwbRecordMemberDef;
+  wbMenuButton: IwbRecordMemberDef;
+  wbLeveledListEntryCreature: IwbRecordMemberDef;
+  wbLeveledListEntryItem: IwbRecordMemberDef;
+  wbLeveledListEntryNPC: IwbRecordMemberDef;
 begin
   wbRecord(PROJ, 'Projectile', [
     wbEDIDReq,
@@ -7553,7 +7562,7 @@ begin
         wbFloat('Max X'),
         wbFloat('Max Y'),
         wbFloat('Max Z'),
-        wbArray('Cells', wbArray('Cell', wbInteger('Triangle', itS16).IncludeFlag(dfNotAlignable), -2)).IncludeFlag(dfNotAlignable) // Divisor is row count² , assumed triangle as the values fit the triangle id's
+        wbArray('Cells', wbArray('Cell', wbInteger('Triangle', itS16).IncludeFlag(dfNotAlignable), -2)).IncludeFlag(dfNotAlignable) // Divisor is row countï¿½ , assumed triangle as the values fit the triangle id's
       ]),
       wbArray(NVEX, 'External Connections', wbStruct('Connection', [
         wbByteArray('Unknown', 4),  // absent in ver<9, not endian swap in ver>=9, so char or byte array
@@ -7890,9 +7899,8 @@ begin
           CCRD, IMOD])
   ]);
 
-  wbRecord(DEBR, 'Debris', [
-    wbEDIDReq,
-    wbRStructs('Models', 'Model', [
+  wbDebrisModel :=
+    wbRStruct('Model', [
       wbStruct(DATA, 'Data', [
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
@@ -7901,7 +7909,11 @@ begin
         ]))
       ], cpNormal, True),
       wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(DEBR, 'Debris', [
+    wbEDIDReq,
+    wbRArray('Models', wbDebrisModel, cpNormal, True)
   ]);
 
   wbRecord(IMGS, 'Image Space', [
@@ -8497,6 +8509,12 @@ begin
     ], cpNormal, True)
   ]);
 
+  wbMenuButton :=
+    wbRStruct('Menu Button', [
+      wbStringKC(ITXT, 'Button Text', 0, cpTranslate),
+      wbCTDAs
+    ], []);
+
   wbRecord(MESG, 'Message', [
     wbEDIDReq,
     wbDESCReq,
@@ -8517,10 +8535,7 @@ begin
       'Auto Display'
     ]), cpNormal, True, False, nil, wbMESGDNAMAfterSet),
     wbInteger(TNAM, 'Display Time', itU32, nil, cpNormal, False, False, wbMESGTNAMDontShow),
-    wbRStructs('Menu Buttons', 'Menu Button', [
-      wbStringKC(ITXT, 'Button Text', 0, cpTranslate),
-      wbCTDAs
-    ], [])
+    wbRArray('Menu Buttons', wbMenuButton)
   ], False, nil, cpNormal, False, wbMESGAfterLoad);
 
   wbRecord(RGDL, 'Ragdoll', [
@@ -10741,6 +10756,9 @@ begin
 end;
 
 procedure DefineFNVf;
+var
+  wbIngredient: IwbRecordMemberDef;
+  wbOutput: IwbRecordMemberDef;
 begin
   wbRecord(WATR, 'Water', [
     wbEDIDReq,
@@ -11813,6 +11831,18 @@ begin
     ]))
   ]);
 
+  wbIngredient :=
+    wbRStruct('Ingredient', [
+      wbFormIDCk(RCIL, 'Item', [ARMO, AMMO, MISC, WEAP, BOOK, KEYM, ALCH, NOTE, IMOD, CMNY, CCRD, CHIP, LIGH], False, cpNormal, True),
+      wbInteger(RCQY, 'Quantity', itU32, nil, cpNormal, True)
+    ], []);
+
+  wbOutput :=
+    wbRStruct('Output', [
+      wbFormIDCk(RCOD, 'Item', [ARMO, AMMO, MISC, WEAP, BOOK, KEYM, ALCH, NOTE, IMOD, CMNY, CCRD, CHIP, LIGH], False, cpNormal, True),
+      wbInteger(RCQY, 'Quantity', itU32, nil, cpNormal, True)
+    ], []);
+
   wbRecord(RCPE, 'Recipe', [
     wbEDIDReq,
     wbFULL,
@@ -11823,14 +11853,8 @@ begin
       wbFormIDCk('Category', [RCCT, NULL]),   // Some of DeadMoney are NULL
       wbFormIDCk('Sub-Category', [RCCT])
     ]),
-    wbRStructs('Ingredients', 'Ingredient', [
-      wbFormIDCk(RCIL, 'Item', [ARMO, AMMO, MISC, WEAP, BOOK, KEYM, ALCH, NOTE, IMOD, CMNY, CCRD, CHIP, LIGH], False, cpNormal, True),
-      wbInteger(RCQY, 'Quantity', itU32, nil, cpNormal, True)
-    ], []),
-    wbRStructs('Outputs', 'Output', [
-      wbFormIDCk(RCOD, 'Item', [ARMO, AMMO, MISC, WEAP, BOOK, KEYM, ALCH, NOTE, IMOD, CMNY, CCRD, CHIP, LIGH], False, cpNormal, True),
-      wbInteger(RCQY, 'Quantity', itU32, nil, cpNormal, True)
-    ], [])
+    wbRArray('Ingredients', wbIngredient),
+    wbRArray('Outputs', wbOutput)
   ]);
 
   wbRecord(REPU, 'Reputation', [

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -5151,7 +5151,7 @@ begin
 
   wbActorValueEnum :=
     wbEnum([
-        {00} 'Aggresion',
+        {00} 'Aggression',
         {01} 'Confidence',
         {02} 'Energy',
         {03} 'Responsibility',
@@ -5299,7 +5299,7 @@ begin
         {08} 'Head Wear',
         {09} 'Hand Wear',
         {10} 'Chems',
-        {11} 'Stimpack',
+        {11} 'Stimpak',
         {12} 'Food',
         {13} 'Alcohol'
       ], [
@@ -6109,7 +6109,7 @@ begin
       {0x00000008} 'Books',
       {0x00000010} 'Food',
       {0x00000020} 'Chems',
-      {0x00000040} 'Stimpacks',
+      {0x00000040} 'Stimpaks',
       {0x00000080} 'Lights?',
       {0x00000100} '',
       {0x00000200} '',
@@ -7897,7 +7897,7 @@ begin
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
         wbInteger('Flags', itU8, wbFlags([
-          'Has Collission Data'
+          'Has Collision Data'
         ]))
       ], cpNormal, True),
       wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
@@ -8581,8 +8581,8 @@ begin
   wbRecord(DOBJ, 'Default Object Manager', [
     wbEDIDReq,
     wbArray(DATA, 'Default Objects', wbFormID('Default Object'), [
-      'Stimpack',
-      'SuperStimpack',
+      'Stimpak',
+      'SuperStimpak',
       'RadX',
       'RadAway',
       'Morphine',
@@ -8863,7 +8863,7 @@ begin
     wbRecord(LAND, 'Landscape', [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -8900,7 +8900,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)
@@ -9524,7 +9524,7 @@ begin
           {20} 'Package Type 20',
           {21} 'Alarm',
           {22} 'Flee',
-          {23} 'TressPass',
+          {23} 'Trespass',
           {24} 'Spectator',
           {25} 'Package Type 25',
           {26} 'Package Type 26',
@@ -10159,7 +10159,7 @@ begin
       'Portal',
       'Debris Small',
       'Debris Large',
-      'Acustic Space',
+      'Acoustic Space',
       'Actor Zone',
       'Projectile Zone',
       'Gas Trap',
@@ -10574,8 +10574,8 @@ begin
     wbInteger(RNAM, 'Random Chance %', itU8),
     wbRUnion('Sound Data', [
       wbStruct(SNDD, 'Sound Data', [
-        wbInteger('Minimum Attentuation Distance', itU8, wbMul(5)),
-        wbInteger('Maximum Attentuation Distance', itU8, wbMul(100)),
+        wbInteger('Minimum Attenuation Distance', itU8, wbMul(5)),
+        wbInteger('Maximum Attenuation Distance', itU8, wbMul(100)),
         wbInteger('Frequency Adjustment %', itS8),
         wbByteArray('Unused', 1),
         wbInteger('Flags', itU32, wbFlags([
@@ -10594,7 +10594,7 @@ begin
           {0x1000} 'Mute When Submerged',
           {0x2000} 'Start at Random Position'
         ])),
-        wbInteger('Static attentuation cdB', itS16),
+        wbInteger('Static attenuation cdB', itS16),
         wbInteger('Stop time ', itU8, wbAlocTime),
         wbInteger('Start time ', itU8, wbAlocTime),
         wbArray('Attenuation Curve', wbInteger('Point', itS16), 5),
@@ -10607,8 +10607,8 @@ begin
 
       ], cpNormal, True),
       wbStruct(SNDX, 'Sound Data', [
-        wbInteger('Minimum attentuation distance', itU8, wbMul(5)),
-        wbInteger('Maximum attentuation distance', itU8, wbMul(100)),
+        wbInteger('Minimum attenuation distance', itU8, wbMul(5)),
+        wbInteger('Maximum attenuation distance', itU8, wbMul(100)),
         wbInteger('Frequency adjustment %', itS8),
         wbByteArray('Unused', 1),
         wbInteger('Flags', itU32, wbFlags([
@@ -10626,7 +10626,7 @@ begin
           {0x0800} '2D Radius',
           {0x1000} 'Mute When Submerged'
         ])),
-        wbInteger('Static attentuation cdB', itS16),
+        wbInteger('Static attenuation cdB', itS16),
         wbInteger('Stop time ', itU8),
         wbInteger('Start time ', itU8)
       ], cpNormal, True)
@@ -10707,7 +10707,7 @@ begin
       wbStringForward(MAST, 'FileName', 0, cpNormal, True),
       wbByteArray(DATA, 'Unused', 8, cpIgnore, True)
     ], [ONAM])).IncludeFlag(dfInternalEditOnly, not wbAllowMasterFilesEdit),
-    wbArray(ONAM, 'Overriden Forms', wbFormIDCk('Form', [REFR, ACHR, ACRE, PMIS, PBEA, PGRE, LAND, NAVM]), 0, nil, nil, cpNormal, False, wbTES4ONAMDontShow),
+    wbArray(ONAM, 'Overridden Forms', wbFormIDCk('Form', [REFR, ACHR, ACRE, PMIS, PBEA, PGRE, LAND, NAVM]), 0, nil, nil, cpNormal, False, wbTES4ONAMDontShow),
     wbByteArray(SCRN, 'Screenshot')
   ], True, nil, cpNormal, True, wbRemoveOFST);
 
@@ -11068,7 +11068,7 @@ begin
         {02} 'Left Attack',
         {03} 'Right Attack',
         {04} 'Left Mobility',
-        {05} 'Right Mobilty',
+        {05} 'Right Mobility',
         {06} 'Brain'
       ])),
       {44} wbFloat('Min Range'),

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -5035,7 +5035,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Merchant Container ----}
     wbFormIDCk(XMRC, 'Merchant Container', [REFR], True),
@@ -6095,7 +6095,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
     wbFormIDCk(XCAS, 'Acoustic Space', [ASPC]),
     wbByteArray(XCMT, 'Unused', 1, cpIgnore),
     wbFormIDCk(XCMO, 'Music Type', [MUSC])
@@ -7585,7 +7585,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -7681,7 +7681,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -7777,7 +7777,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -10284,7 +10284,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Lock ---}
     wbStruct(XLOC, 'Lock Data', [

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -4622,12 +4622,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -4636,12 +4636,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMODS :=
@@ -4967,13 +4967,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -5061,13 +5061,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -6037,19 +6037,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Directional Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Fog Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fog Near'),
       wbFloat('Fog Far'),
       wbInteger('Directional Rotation XY', itS32),
@@ -6799,7 +6799,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fill/Texture Effect - Alpha Fade In Time'),
       wbFloat('Fill/Texture Effect - Full Alpha Time'),
       wbFloat('Fill/Texture Effect - Alpha Fade Out Time'),
@@ -6814,7 +6814,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Edge Effect - Alpha Fade In Time'),
       wbFloat('Edge Effect - Full Alpha Time'),
       wbFloat('Edge Effect - Alpha Fade Out Time'),
@@ -6852,19 +6852,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 2 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 3 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Color Key 1 - Color Alpha'),
       wbFloat('Color Key 2 - Color Alpha'),
       wbFloat('Color Key 3 - Color Alpha'),
@@ -6887,7 +6887,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Explosion Wind Speed'),
       wbInteger('Texture Count U', itU32),
       wbInteger('Texture Count V', itU32),
@@ -7025,7 +7025,7 @@ begin
                 wbInteger('Green', itU8),
                 wbInteger('Blue', itU8),
                 wbByteArray('Unused', 1)
-              ])
+              ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
             ]);
 
   wbRecord(TXST, 'Texture Set', [
@@ -7200,12 +7200,12 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbStruct('Rotation', [
           wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
     ], [], cpNormal, True)
@@ -7372,7 +7372,7 @@ begin
       {68}   wbFloat('X'),
       {72}   wbFloat('Y'),
       {76}   wbFloat('Z')
-           ]),
+           ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       {80} wbFloat('Bouncy Mult')
     ], cpNormal, True, nil, 18),
     wbRStructSK([0], 'Muzzle Flash Model', [
@@ -7472,7 +7472,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ])).IncludeFlag(dfNotAlignable),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)).IncludeFlag(dfNotAlignable),
       wbArray(NVTR, 'Triangles', wbStruct('Triangle', [
         wbArray('Vertices', wbInteger('Vertex', itS16), 3),
         wbArray('Edges', wbInteger('Triangle', itS16, wbNVTREdgeToStr, wbNVTREdgeToInt), [
@@ -7619,13 +7619,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7715,13 +7715,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7811,13 +7811,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7942,7 +7942,7 @@ begin
           {84} wbFloat('Red', cpNormal, False, 255, 0),
           {88} wbFloat('Green', cpNormal, False, 255, 0),
           {92} wbFloat('Blue', cpNormal, False, 255, 0)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       {96} wbFloat('Brightness')
       ]),
       wbStruct('Cinematic', [
@@ -7957,7 +7957,7 @@ begin
             {116} wbFloat('Red', cpNormal, False, 255, 0),
             {120} wbFloat('Green', cpNormal, False, 255, 0),
             {124} wbFloat('Blue', cpNormal, False, 255, 0)
-          ]),
+          ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         {128} wbFloat('Value')
         ])
       ]),
@@ -8314,12 +8314,12 @@ begin
         {44} wbFloat('X'),
         {48} wbFloat('Y'),
         {52} wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         {56} wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         {60} wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         {64} wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]),
     {68} wbFormIDCk('Severable - Impact DataSet', [IPDS, NULL]),
     {72} wbFormIDCk('Explodable - Impact DataSet', [IPDS, NULL]),
@@ -8626,19 +8626,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Directional Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Fog Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fog Near'),
       wbFloat('Fog Far'),
       wbInteger('Directional Rotation XY', itS32),
@@ -8898,7 +8898,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -8912,7 +8912,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -8960,7 +8960,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbInteger('Unused', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Flags', itU32, wbFlags([
         {0x00000001} 'Dynamic',
         {0x00000002} 'Can be Carried',
@@ -9456,7 +9456,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True, wbActorTemplateUseModelAnimation),
+    ], cpNormal, True, wbActorTemplateUseModelAnimation).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(ZNAM, 'Combat Style', [CSTY], False, cpNormal, False, wbActorTemplateUseTraits),
     wbInteger(NAM4, 'Impact Material Type', itU32, wbImpactMaterialTypeEnum, cpNormal, True, False, wbActorTemplateUseModelAnimation),
     wbFaceGenNPC,
@@ -10123,12 +10123,12 @@ begin
         wbFloat('X', cpNormal, True, 2, 4),
         wbFloat('Y', cpNormal, True, 2, 4),
         wbFloat('Z', cpNormal, True, 2, 4)
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Color', [
         {84} wbFloat('Red', cpNormal, False, 255, 0),
         {88} wbFloat('Green', cpNormal, False, 255, 0),
         {92} wbFloat('Blue', cpNormal, False, 255, 0)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Unknown'),
       wbInteger('Type', itU32, wbEnum([
         'None',
@@ -10191,7 +10191,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
 
     {--- Teleport ---}
     wbStruct(XTEL, 'Teleport Destination', [
@@ -10339,13 +10339,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -10399,7 +10399,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -10429,7 +10429,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -10460,7 +10460,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
 
     wbRArray('Region Areas', wbRStruct('Region Area', [
@@ -10525,7 +10525,7 @@ begin
           wbInteger('X', itU16),
           wbInteger('Y', itU16),
           wbInteger('Z', itU16)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbByteArray('Unused', 2),
         wbByteArray('Unknown', 4)
       ]), 0, nil, nil, cpNormal, False, wbREGNObjectsDontShow),
@@ -10772,19 +10772,19 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Deep Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Reflection Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbByteArray('Unused', 4),
         wbFloat('Rain Simulator - Force'),
         wbFloat('Rain Simulator - Velocity'),
@@ -10838,19 +10838,19 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Deep Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Reflection Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbByteArray('Unused', 4),
         wbFloat('Rain Simulator - Force'),
         wbFloat('Rain Simulator - Velocity'),
@@ -11373,7 +11373,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         ['Sunrise', 'Day', 'Sunset', 'Night', 'High Noon', 'Midnight']
       ),
     4),
@@ -11384,7 +11384,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         ['Sunrise', 'Day', 'Sunset', 'Night', 'High Noon', 'Midnight']
       ),
       ['Sky-Upper','Fog','Unused','Ambient','Sunlight','Sun','Stars','Sky-Lower','Horizon','Unused']
@@ -11415,7 +11415,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ], cpNormal, True),
     wbRArray('Sounds', wbStruct(SNAM, 'Sound', [
       wbFormIDCk('Sound', [SOUN]),

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4876,7 +4876,7 @@ begin
 
   wbActorValueEnum :=
     wbEnum([
-        {00} 'Aggresion',
+        {00} 'Aggression',
         {01} 'Confidence',
         {02} 'Energy',
         {03} 'Responsibility',
@@ -4999,7 +4999,7 @@ begin
         {08} 'Head Wear',
         {09} 'Hand Wear',
         {10} 'Chems',
-        {11} 'Stimpack',
+        {11} 'Stimpak',
         {12} 'Food',
         {13} 'Alcohol'
       ], [
@@ -5709,7 +5709,7 @@ begin
       {0x00000008} 'Books',
       {0x00000010} 'Food',
       {0x00000020} 'Chems',
-      {0x00000040} 'Stimpacks',
+      {0x00000040} 'Stimpaks',
       {0x00000080} 'Lights?',
       {0x00000100} '',
       {0x00000200} '',
@@ -7436,7 +7436,7 @@ begin
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
         wbInteger('Flags', itU8, wbFlags([
-          'Has Collission Data'
+          'Has Collision Data'
         ]))
       ], cpNormal, True),
       wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
@@ -8070,8 +8070,8 @@ begin
   wbRecord(DOBJ, 'Default Object Manager', [
     wbEDIDReq,
     wbArray(DATA, 'Default Objects', wbFormID('Default Object'), [
-      'Stimpack',
-      'SuperStimpack',
+      'Stimpak',
+      'SuperStimpak',
       'RadX',
       'RadAway',
       'Morphine',
@@ -8332,7 +8332,7 @@ begin
     wbRecord(LAND, 'Landscape', [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -8369,7 +8369,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)
@@ -9580,7 +9580,7 @@ begin
       'Portal',
       'Debris Small',
       'Debris Large',
-      'Acustic Space',
+      'Acoustic Space',
       'Actor Zone',
       'Projectile Zone',
       'Gas Trap',
@@ -9976,8 +9976,8 @@ begin
     wbString(FNAM, 'Sound FileName'),
     wbRUnion('Sound Data', [
       wbStruct(SNDD, 'Sound Data', [
-        wbInteger('Minimum Attentuation Distance', itU8, wbMul(5)),
-        wbInteger('Maximum Attentuation Distance', itU8, wbMul(100)),
+        wbInteger('Minimum Attenuation Distance', itU8, wbMul(5)),
+        wbInteger('Maximum Attenuation Distance', itU8, wbMul(100)),
         wbInteger('Frequency Adjustment %', itS8),
         wbByteArray('Unused', 1),
         wbInteger('Flags', itU32, wbFlags([
@@ -9995,7 +9995,7 @@ begin
           {0x0800} '2D Radius',
           {0x1000} 'Mute When Submerged'
         ])),
-        wbInteger('Static attentuation cdB', itS16),
+        wbInteger('Static attenuation cdB', itS16),
         wbInteger('Stop time ', itU8),
         wbInteger('Start time ', itU8),
         wbArray('Attenuation Curve', wbInteger('Point', itS16), 5),
@@ -10004,8 +10004,8 @@ begin
         wbByteArray('Unknown', 8)
       ], cpNormal, True),
       wbStruct(SNDX, 'Sound Data', [
-        wbInteger('Minimum attentuation distance', itU8, wbMul(5)),
-        wbInteger('Maximum attentuation distance', itU8, wbMul(100)),
+        wbInteger('Minimum attenuation distance', itU8, wbMul(5)),
+        wbInteger('Maximum attenuation distance', itU8, wbMul(100)),
         wbInteger('Frequency adjustment %', itS8),
         wbByteArray('Unused', 1),
         wbInteger('Flags', itU32, wbFlags([
@@ -10023,7 +10023,7 @@ begin
           {0x0800} '2D Radius',
           {0x1000} 'Mute When Submerged'
         ])),
-        wbInteger('Static attentuation cdB', itS16),
+        wbInteger('Static attenuation cdB', itS16),
         wbInteger('Stop time ', itU8),
         wbInteger('Start time ', itU8)
       ], cpNormal, True)
@@ -10089,7 +10089,7 @@ begin
       wbStringForward(MAST, 'FileName', 0, cpNormal, True),
       wbByteArray(DATA, 'Unused', 8, cpIgnore, True)
     ], [ONAM])).IncludeFlag(dfInternalEditOnly, not wbAllowMasterFilesEdit),
-    wbArray(ONAM, 'Overriden Forms', wbFormIDCk('Form', [REFR, ACHR, ACRE, PMIS, PBEA, PGRE, LAND, NAVM]), 0, nil, nil, cpNormal, False, wbTES4ONAMDontShow),
+    wbArray(ONAM, 'Overridden Forms', wbFormIDCk('Form', [REFR, ACHR, ACRE, PMIS, PBEA, PGRE, LAND, NAVM]), 0, nil, nil, cpNormal, False, wbTES4ONAMDontShow),
     wbByteArray(SCRN, 'Screenshot')
   ], True, nil, cpNormal, True, wbRemoveOFST);
 
@@ -10387,7 +10387,7 @@ begin
         {02} 'Left Attack',
         {03} 'Right Attack',
         {04} 'Left Mobility',
-        {05} 'Right Mobilty',
+        {05} 'Right Mobility',
         {06} 'Brain'
       ])),
       {44} wbFloat('Min Range'),

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4764,7 +4764,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Merchant Container ----}
     wbFormIDCk(XMRC, 'Merchant Container', [REFR], True),
@@ -5695,7 +5695,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
     wbFormIDCk(XCAS, 'Acoustic Space', [ASPC]),
     wbByteArray(XCMT, 'Unused', 1, cpIgnore),
     wbFormIDCk(XCMO, 'Music Type', [MUSC])
@@ -7131,7 +7131,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -7225,7 +7225,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -7319,7 +7319,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Extra ---}
     wbInteger(XCNT, 'Count', itS32),
@@ -9694,7 +9694,7 @@ begin
     wbRStruct('Ownership', [
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32)
-    ], [XCMT, XCMO]),
+    ], [XCMT, XCMO]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
 
     {--- Lock ---}
     wbStruct(XLOC, 'Lock Data', [

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4352,12 +4352,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -4366,12 +4366,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMODS :=
@@ -4698,13 +4698,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -4790,13 +4790,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -5637,19 +5637,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Directional Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Fog Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fog Near'),
       wbFloat('Fog Far'),
       wbInteger('Directional Rotation XY', itS32),
@@ -6371,7 +6371,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fill/Texture Effect - Alpha Fade In Time'),
       wbFloat('Fill/Texture Effect - Full Alpha Time'),
       wbFloat('Fill/Texture Effect - Alpha Fade Out Time'),
@@ -6386,7 +6386,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Edge Effect - Alpha Fade In Time'),
       wbFloat('Edge Effect - Full Alpha Time'),
       wbFloat('Edge Effect - Alpha Fade Out Time'),
@@ -6424,19 +6424,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 2 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 3 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Color Key 1 - Color Alpha'),
       wbFloat('Color Key 2 - Color Alpha'),
       wbFloat('Color Key 3 - Color Alpha'),
@@ -6459,7 +6459,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Explosion Wind Speed'),
       wbInteger('Texture Count U', itU32),
       wbInteger('Texture Count V', itU32),
@@ -6596,7 +6596,7 @@ begin
                 wbInteger('Green', itU8),
                 wbInteger('Blue', itU8),
                 wbByteArray('Unused', 1)
-              ])
+              ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
             ]);
 
   wbRecord(TXST, 'Texture Set', [
@@ -6762,12 +6762,12 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbStruct('Rotation', [
           wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
     ], [], cpNormal, True)
@@ -7018,7 +7018,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ])).IncludeFlag(dfNotAlignable),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)).IncludeFlag(dfNotAlignable),
       wbArray(NVTR, 'Triangles', wbStruct('Triangle', [
         wbArray('Vertices', wbInteger('Vertex', itS16), 3),
         wbArray('Edges', wbInteger('Triangle', itS16, wbNVTREdgeToStr, wbNVTREdgeToInt), [
@@ -7165,13 +7165,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7259,13 +7259,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7353,13 +7353,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -7481,7 +7481,7 @@ begin
           {84} wbFloat('Red', cpNormal, False, 255, 0),
           {88} wbFloat('Green', cpNormal, False, 255, 0),
           {92} wbFloat('Blue', cpNormal, False, 255, 0)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       {96} wbFloat('Brightness')
       ]),
       wbStruct('Cinematic', [
@@ -7496,7 +7496,7 @@ begin
             {116} wbFloat('Red', cpNormal, False, 255, 0),
             {120} wbFloat('Green', cpNormal, False, 255, 0),
             {124} wbFloat('Blue', cpNormal, False, 255, 0)
-          ]),
+          ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         {128} wbFloat('Value')
         ])
       ]),
@@ -7812,12 +7812,12 @@ begin
         {44} wbFloat('X'),
         {48} wbFloat('Y'),
         {52} wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         {56} wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         {60} wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         {64} wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]),
     {68} wbFormIDCk('Severable - Impact DataSet', [IPDS, NULL]),
     {72} wbFormIDCk('Explodable - Impact DataSet', [IPDS, NULL]),
@@ -8102,19 +8102,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Directional Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Fog Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fog Near'),
       wbFloat('Fog Far'),
       wbInteger('Directional Rotation XY', itS32),
@@ -8367,7 +8367,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -8381,7 +8381,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -8429,7 +8429,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbInteger('Unused', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Flags', itU32, wbFlags([
         {0x00000001} 'Dynamic',
         {0x00000002} 'Can be Carried',
@@ -8901,7 +8901,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True, wbActorTemplateUseModelAnimation),
+    ], cpNormal, True, wbActorTemplateUseModelAnimation).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(ZNAM, 'Combat Style', [CSTY], False, cpNormal, False, wbActorTemplateUseTraits),
     wbInteger(NAM4, 'Impact Material Type', itU32, wbImpactMaterialTypeEnum, cpNormal, True, False, wbActorTemplateUseModelAnimation),
     wbFaceGenNPC,
@@ -9544,12 +9544,12 @@ begin
         wbFloat('X', cpNormal, True, 2, 4),
         wbFloat('Y', cpNormal, True, 2, 4),
         wbFloat('Z', cpNormal, True, 2, 4)
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Color', [
         {84} wbFloat('Red', cpNormal, False, 255, 0),
         {88} wbFloat('Green', cpNormal, False, 255, 0),
         {92} wbFloat('Blue', cpNormal, False, 255, 0)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Unknown'),
       wbInteger('Type', itU32, wbEnum([
         'None',
@@ -9612,7 +9612,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
 
     {--- Teleport ---}
     wbStruct(XTEL, 'Teleport Destination', [
@@ -9749,13 +9749,13 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Link End Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ]),
 
     {--- Activate Parents ---}
@@ -9807,7 +9807,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -9837,7 +9837,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -9868,7 +9868,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
 
     wbRArray('Region Areas', wbRStruct('Region Area', [
@@ -9933,7 +9933,7 @@ begin
           wbInteger('X', itU16),
           wbInteger('Y', itU16),
           wbInteger('Z', itU16)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbByteArray('Unused', 2),
         wbByteArray('Unknown', 4)
       ]), 0, nil, nil, cpNormal, False, wbREGNObjectsDontShow),
@@ -10153,19 +10153,19 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Deep Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Reflection Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbByteArray('Unused', 4),
         wbFloat('Rain Simulator - Force'),
         wbFloat('Rain Simulator - Velocity'),
@@ -10219,19 +10219,19 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Deep Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbStruct('Reflection Color', [
           wbInteger('Red', itU8),
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbByteArray('Unused', 4),
         wbFloat('Rain Simulator - Force'),
         wbFloat('Rain Simulator - Velocity'),
@@ -10660,7 +10660,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         ['Sunrise', 'Day', 'Sunset', 'Night']
       ),
     4),
@@ -10671,7 +10671,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         ['Sunrise', 'Day', 'Sunset', 'Night']
       ),
       ['Sky-Upper','Fog','Unused','Ambient','Sunlight','Sun','Stars','Sky-Lower','Horizon','Unused']
@@ -10702,7 +10702,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ], cpNormal, True),
     wbRArray('Sounds', wbStruct(SNAM, 'Sound', [
       wbFormIDCk('Sound', [SOUN]),

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -1,4 +1,4 @@
-{*******************************************************************************
+ï»¿{*******************************************************************************
 
      The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
@@ -5140,6 +5140,8 @@ begin
 end;
 
 procedure DefineFO3b;
+var
+  wbEffect: IwbRecordMemberDef;
 begin
   wbMiscStatEnum :=
     wbEnum([
@@ -5415,20 +5417,18 @@ begin
   wbCTDAs := wbRArray('Conditions', wbCTDA);
   wbCTDAsReq := wbRArray('Conditions', wbCTDA, cpNormal, True);
 
-  wbEffects :=
-    wbRStructs('Effects','Effect', [
+  wbEffect :=
+    wbRStruct('Effect', [
       wbEFID,
       wbEFIT,
       wbCTDAs
     ], []);
 
-  wbEffectsReq :=
-    wbRStructs('Effects','Effect', [
-      wbEFID,
-      wbEFIT,
-      wbCTDAs
-    ], [], cpNormal, True);
+  wbEffects :=
+    wbRArray('Effects', wbEffect);
 
+  wbEffectsReq :=
+    wbRArray('Effects', wbEffect, cpNormal, True);
 
   wbRecord(ALCH, 'Ingestible', [
     wbEDIDReq,
@@ -6173,6 +6173,9 @@ begin
 end;
 
 procedure DefineFO3d;
+var
+  wbFactionRank: IwbRecordMemberDef;
+  wbStaticPart: IwbRecordMemberDef;
 begin
   wbRecord(CSTY, 'Combat Style', [
     wbEDIDReq,
@@ -6519,6 +6522,14 @@ begin
 
   wbXNAMs := wbRArrayS('Relations', wbXNAM);
 
+  wbFactionRank :=
+    wbRStructSK([0], 'Rank', [
+      wbInteger(RNAM, 'Rank#', itS32),
+      wbString(MNAM, 'Male', 0, cpTranslate),
+      wbString(FNAM, 'Female', 0, cpTranslate),
+      wbString(INAM, 'Insignia (Unused)')
+    ], []);
+
   wbRecord(FACT, 'Faction', [
     wbEDIDReq,
     wbFULL,
@@ -6536,12 +6547,7 @@ begin
       wbByteArray('Unused', 2)
     ], cpNormal, True, nil, 1),
     wbFloat(CNAM, 'Unused'),
-    wbRStructsSK('Ranks', 'Rank', [0], [
-      wbInteger(RNAM, 'Rank#', itS32),
-      wbString(MNAM, 'Male', 0, cpTranslate),
-      wbString(FNAM, 'Female', 0, cpTranslate),
-      wbString(INAM, 'Insignia (Unused)')
-    ], [])
+    wbRArrayS('Ranks', wbFactionRank)
   ], False, nil, cpNormal, False, wbFACTAfterLoad);
 
   wbRecord(FURN, 'Furniture', [
@@ -6751,11 +6757,8 @@ begin
     )
   ]);
 
-  wbRecord(SCOL, 'Static Collection', [
-    wbEDIDReq,
-    wbOBNDReq,
-    wbMODLReq,
-    wbRStructs('Parts', 'Part', [
+  wbStaticPart :=
+    wbRStruct('Part', [
       wbFormIDCk(ONAM, 'Static', [STAT]),
       wbArrayS(DATA, 'Placements', wbStruct('Placement', [
         wbStruct('Position', [
@@ -6770,7 +6773,13 @@ begin
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(SCOL, 'Static Collection', [
+    wbEDIDReq,
+    wbOBNDReq,
+    wbMODLReq,
+    wbRArray('Parts', wbStaticPart, cpNormal, True)
   ]);
 
   wbRecord(MSTT, 'Moveable Static', [
@@ -6873,6 +6882,10 @@ begin
 end;
 
 procedure DefineFO3e;
+var
+  wbDebrisModel: IwbRecordMemberDef;
+  wbPerkEffect: IwbRecordMemberDef;
+  wbMenuButton: IwbRecordMemberDef;
 begin
   wbRecord(PROJ, 'Projectile', [
     wbEDIDReq,
@@ -7099,7 +7112,7 @@ begin
         wbFloat('Max X'),
         wbFloat('Max Y'),
         wbFloat('Max Z'),
-        wbArray('Cells', wbArray('Cell', wbInteger('Triangle', itS16).IncludeFlag(dfNotAlignable), -2)).IncludeFlag(dfNotAlignable) // Divisor is row count² , assumed triangle as the values fit the triangle id's
+        wbArray('Cells', wbArray('Cell', wbInteger('Triangle', itS16).IncludeFlag(dfNotAlignable), -2)).IncludeFlag(dfNotAlignable) // Divisor is row countï¿½ , assumed triangle as the values fit the triangle id's
       ]),
       wbArray(NVEX, 'External Connections', wbStruct('Connection', [
         wbByteArray('Unknown', 4),
@@ -7429,9 +7442,8 @@ begin
           ASPC, IDLM, ARMA, MSTT, NOTE, PWAT, SCOL, TACT, TERM, TXST])
   ]);
 
-  wbRecord(DEBR, 'Debris', [
-    wbEDIDReq,
-    wbRStructs('Models', 'Model', [
+  wbDebrisModel :=
+    wbRStruct('Model', [
       wbStruct(DATA, 'Data', [
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
@@ -7440,7 +7452,11 @@ begin
         ]))
       ], cpNormal, True),
       wbByteArray(MODT, 'Texture Files Hashes', 0, cpIgnore)
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(DEBR, 'Debris', [
+    wbEDIDReq,
+    wbRArray('Models', wbDebrisModel, cpNormal, True)
   ]);
 
   wbRecord(IMGS, 'Image Space', [
@@ -7662,20 +7678,8 @@ begin
     wbRArrayS('FormIDs', wbFormID(LNAM, 'FormID'), cpNormal, False, nil, nil, nil, wbFLSTLNAMIsSorted)
   ]);
 
-  wbRecord(PERK, 'Perk', [
-    wbEDIDReq,
-    wbFULL,
-    wbDESCReq,
-    wbICON,
-    wbCTDAs,
-    wbStruct(DATA, 'Data', [
-      wbInteger('Trait', itU8, wbEnum(['No', 'Yes'])),
-      wbInteger('Min Level', itU8),
-      wbInteger('Ranks', itU8),
-      wbInteger('Playable', itU8, wbEnum(['No', 'Yes'])),
-      wbInteger('Hidden', itU8, wbEnum(['No', 'Yes']))
-    ], cpNormal, True, nil, 4),
-    wbRStructsSK('Effects', 'Effect', [0, 1], [
+  wbPerkEffect :=
+    wbRStructSK([0, 1], 'Effect', [
       wbStructSK(PRKE, [1, 2, 0], 'Header', [
         wbInteger('Type', itU8, wbEnum([
           'Quest + Stage',
@@ -7763,7 +7767,22 @@ begin
         wbEmbeddedScriptPerk
       ], [], cpNormal, False, wbPERKPRKCDontShow),
       wbEmpty(PRKF, 'End Marker', cpIgnore, True)
-    ], [])
+    ], []);
+
+  wbRecord(PERK, 'Perk', [
+    wbEDIDReq,
+    wbFULL,
+    wbDESCReq,
+    wbICON,
+    wbCTDAs,
+    wbStruct(DATA, 'Data', [
+      wbInteger('Trait', itU8, wbEnum(['No', 'Yes'])),
+      wbInteger('Min Level', itU8),
+      wbInteger('Ranks', itU8),
+      wbInteger('Playable', itU8, wbEnum(['No', 'Yes'])),
+      wbInteger('Hidden', itU8, wbEnum(['No', 'Yes']))
+    ], cpNormal, True, nil, 4),
+    wbRArrayS('Effects', wbPerkEffect)
   ]);
 
   wbBPNDStruct := wbStruct(BPND, '', [
@@ -7986,6 +8005,12 @@ begin
     ], cpNormal, True)
   ]);
 
+  wbMenuButton :=
+    wbRStruct('Menu Button', [
+      wbStringKC(ITXT, 'Button Text', 0, cpTranslate),
+      wbCTDAs
+    ], []);
+
   wbRecord(MESG, 'Message', [
     wbEDIDReq,
     wbDESCReq,
@@ -8006,10 +8031,7 @@ begin
       'Auto Display'
     ]), cpNormal, True, False, nil, wbMESGDNAMAfterSet),
     wbInteger(TNAM, 'Display Time', itU32, nil, cpNormal, False, False, wbMESGTNAMDontShow),
-    wbRStructs('Menu Buttons', 'Menu Button', [
-      wbStringKC(ITXT, 'Button Text', 0, cpTranslate),
-      wbCTDAs
-    ], [])
+    wbRArray('Menu Buttons', wbMenuButton)
   ], False, nil, cpNormal, False, wbMESGAfterLoad);
 
   wbRecord(RGDL, 'Ragdoll', [

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -1011,7 +1011,7 @@ var
   wbKWDAs: IwbSubRecordDef;
   wbReqKWDAs: IwbSubRecordDef;
   wbKeywords: IwbSubRecordStructDef;
-  wbCNAM: IwbSubRecordDef;
+  wbCNAM: IwbRecordMemberDef;
   wbCITC: IwbSubRecordDef;
   wbCITCReq: IwbSubRecordDef;
   wbMGEFData: IwbSubRecordStructDef;
@@ -5943,23 +5943,23 @@ begin
     Result := 7;
 end;
 
-function wbByteColors(const aName: string = 'Color'): IwbStructDef;
+function wbByteColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbInteger('Red', itU8),
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unused', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
-function wbFloatColors(const aName: string = 'Color'): IwbStructDef;
+function wbFloatColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbFloat('Red', cpNormal, True, 255, 0),
     wbFloat('Green', cpNormal, True, 255, 0),
     wbFloat('Blue', cpNormal, True, 255, 0)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
 function wbWeatherColors(const aName: string): IwbStructDef;
@@ -6645,7 +6645,7 @@ begin
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unknown', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 
   wbDODT := wbStruct(DODT, 'Decal Data', [
     wbFloat('Min Width'),
@@ -7530,12 +7530,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -7544,12 +7544,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMODS := wbFormIDCk(MODS, 'Material Swap', [MSWP]);
@@ -7873,7 +7873,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]), -1).IncludeFlag(dfNotAlignable),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable),
       wbArray('Triangles',
         wbStruct('Triangle', [
           wbInteger('Vertex 0', itS16, wbVertexToStr0, wbVertexToInt0).SetLinksToCallback(wbVertexLinksTo),
@@ -9295,7 +9295,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(SNAM, 'Sound - Looping', [SNDR]),
     wbFormIDCk(VNAM, 'Sound - Activation', [SNDR]),
     wbFormIDCk(WNAM, 'Water Type', [WATR]),
@@ -11080,7 +11080,7 @@ begin
                 wbFloat('X'),
                 wbFloat('Y'),
                 wbFloat('Z')
-              ]), -1)
+              ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1)
             ])
           ]),
           wbByteArray('Unknown', 4),
@@ -11753,7 +11753,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True, nil, 9),
     wbFormIDCk(MNAM, 'Image Space Modifier', [IMAD])
   ]);
@@ -11791,7 +11791,7 @@ begin
       wbFloat('Red', cpNormal, True, 255, 0),
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFloat(BNAM, 'Buoyancy'),
     wbInteger(FNAM, 'Flags', itU32, wbFlags([
       'Stair Material',
@@ -12913,7 +12913,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbFloat('Normal Dampener'),
       wbFloatColors('Single Pass Color'),
       wbInteger('Flags', itU32, wbFlags(['Single Pass']))
@@ -13075,7 +13075,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbInteger(GNAM, 'Flags', itU32, wbFlags([
       {0x00000001} 'Trigger Volume',
       {0x00000002} 'Sensor',
@@ -13388,7 +13388,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -13402,7 +13402,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -14026,7 +14026,7 @@ begin
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0),
       wbFloat('Alpha')
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbArray(MSDK, 'Morph Keys', wbInteger('Key', itU32, wbMorphValueToStr, wbHexStrToInt)),
     wbArray(MSDV, 'Morph Values', wbFloat('Value')),
     wbRArrayS('Face Tinting Layers',
@@ -15115,7 +15115,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
 
     {--- Primitive ---}
     wbStruct(XPRM, 'Primitive', [
@@ -15123,7 +15123,7 @@ begin
         wbFloat('X', cpNormal, True, 2, 4),
         wbFloat('Y', cpNormal, True, 2, 4),
         wbFloat('Z', cpNormal, True, 2, 4)
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbFloatColors('Color'),
       wbFloat('Unknown'),
       wbInteger('Type', itU32, wbEnum([
@@ -15151,7 +15151,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -15171,7 +15171,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -15542,7 +15542,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unknown', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
     wbRArray('Region Areas', wbRStruct('Region Area', [
       wbInteger(RPLI, 'Edge Fall-off', itU32),
@@ -15631,7 +15631,7 @@ begin
           wbInteger('X', itU16),
           wbInteger('Y', itU16),
           wbInteger('Z', itU16)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbByteArray('Unknown', 2),
         wbByteArray('Unknown', 4)
       ]), 0, nil, nil, cpNormal, False, wbREGNObjectsDontShow),
@@ -15990,12 +15990,12 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbStruct(NAM1, 'Angular Velocity', [
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbString(NAM2, 'Layer 1 Noise Texture'),
     wbString(NAM3, 'Layer 2 Noise Texture'),
     wbString(NAM4, 'Layer 3 Noise Texture')
@@ -16390,7 +16390,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Visual Effect - Begin', itU8), // scaled 0..1
       wbInteger('Visual Effect - End', itU8), // scaled 0..1
       wbInteger('Wind Direction', itU8), // scaled 0..360
@@ -16891,12 +16891,12 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbStruct('Rotation', [
           wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
     ], [], cpNormal, True)
@@ -17051,7 +17051,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ])
   ]);
 

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -1064,9 +1064,6 @@ var
   wbMaxHeightDataCELL: IwbSubRecordDef;
   wbMaxHeightDataWRLD: IwbSubRecordDef;
   wbOFST: IwbSubRecordDef;
-  wbFaction: IwbRecordMemberDef;
-  wbLeveledListEntryItem: IwbRecordMemberDef;
-  wbLeveledListEntryNPC: IwbRecordMemberDef;
 
 function Sig2Int(aSignature: TwbSignature): Cardinal; inline;
 begin
@@ -8004,6 +8001,9 @@ Can't properly represent that with current record definition methods.
 end;
 
 procedure DefineFO4b;
+var
+  wbBoneDataItem: IwbRecordMemberDef;
+  wbEffect: IwbRecordMemberDef;
 begin
   wbRefRecord(ACHR, 'Placed NPC',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -9236,7 +9236,8 @@ begin
     wbEmpty(STOP, 'Marker', cpNormal, True)
   ], []);
 
-  wbBSMPSequence := wbRStructs('Bone Data', 'Data', [
+  wbBoneDataItem :=
+    wbRStruct('Data', [
     wbInteger(BSMP, 'Gender', itU32, wbEnum(['Male', 'Female'])),
     // should not be sorted!!!
     wbRArray('Bones',
@@ -9248,12 +9249,17 @@ begin
     )
   ], []);
 
-  wbEffectsReq :=
-    wbRStructs('Effects', 'Effect', [
+  wbBSMPSequence := wbRArray('Bone Data', wbBoneDataItem);
+
+  wbEffect :=
+    wbRStruct('Effect', [
       wbEFID,
       wbEFIT,
       wbCTDAs
     ], [], cpNormal, True);
+
+  wbEffectsReq :=
+    wbRArray('Effects', wbEffect, cpNormal, True);
 
   wbRecord(ACTI, 'Activator',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -10048,6 +10054,8 @@ begin
 end;
 
 procedure DefineFO4d;
+var
+  wbFactionRank: IwbRecordMemberDef;
 begin
   wbRecord(DIAL, 'Dialog Topic', [
     wbEDID,
@@ -10548,6 +10556,14 @@ begin
 
   wbXNAMs := wbRArrayS('Relations', wbXNAM);
 
+  wbFactionRank :=
+    wbRStructSK([0], 'Rank', [
+      wbInteger(RNAM, 'Rank#', itU32),
+      wbLString(MNAM, 'Male Title', 0, cpTranslate),
+      wbLString(FNAM, 'Female Title', 0, cpTranslate),
+      wbString(INAM, 'Insignia (unused)')
+    ], []);
+
   wbRecord(FACT, 'Faction', [
     wbEDID,
     wbFULL,
@@ -10591,12 +10607,7 @@ begin
       wbInteger('Escape', itU16),
       wbInteger('Werewolf (unused)', itU16)
     ], cpNormal, False, nil, 7),
-    wbRStructsSK('Ranks', 'Rank', [0], [
-      wbInteger(RNAM, 'Rank#', itU32),
-      wbLString(MNAM, 'Male Title', 0, cpTranslate),
-      wbLString(FNAM, 'Female Title', 0, cpTranslate),
-      wbString(INAM, 'Insignia (unused)')
-    ], []),
+    wbRArrayS('Ranks', wbFactionRank),
     wbFormIDCk(VEND, 'Vendor Buy/Sell List', [FLST]),
     wbFormIDCk(VENC, 'Merchant Container', [REFR]),
     wbStruct(VENV, 'Vendor Values', [
@@ -10726,6 +10737,8 @@ begin
 end;
 
 procedure DefineFO4e;
+var
+  wbHeadPartPart: IwbRecordMemberDef;
 begin
   wbRecord(LCRT, 'Location Reference Type', [
     wbEDID,
@@ -10767,6 +10780,16 @@ begin
     wbString(MNAM, 'Material')
   ]);
 
+  wbHeadPartPart :=
+    wbRStruct('Part', [
+      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
+        'Race Morph',
+        'Tri',
+        'Chargen Morph'
+      ])),
+      wbString(NAM1, 'FileName', 0, cpTranslate, True)
+    ], []);
+
   wbRecord(HDPT, 'Head Part',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  2, 'Non-Playable'
@@ -10797,14 +10820,7 @@ begin
     wbRArrayS('Extra Parts',
       wbFormIDCk(HNAM, 'Part', [HDPT])
     ),
-    wbRStructs('Parts', 'Part', [
-      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
-        'Race Morph',
-        'Tri',
-        'Chargen Morph'
-      ])),
-      wbString(NAM1, 'FileName', 0, cpTranslate, True)
-    ], []),
+    wbRArray('Parts', wbHeadPartPart),
     wbFormIDCk(TNAM, 'Texture Set', [TXST]),
     wbFormIDCk(CNAM, 'Color', [CLFM]),
     wbFormIDCk(RNAM, 'Valid Races', [FLST]),
@@ -11121,6 +11137,9 @@ begin
 end;
 
 procedure DefineFO4g;
+var
+  wbDebrisModel: IwbRecordMemberDef;
+  wbPerkEffect: IwbRecordMemberDef;
 begin
 
    wbRecord(EXPL, 'Explosion', [
@@ -11178,9 +11197,8 @@ begin
     ], cpNormal, True, nil, 13)
   ]);
 
-  wbRecord(DEBR, 'Debris', [
-    wbEDID,
-    wbRStructs('Models', 'Model', [
+  wbDebrisModel :=
+    wbRStruct('Model', [
       wbStruct(DATA, 'Data', [
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
@@ -11189,7 +11207,11 @@ begin
         ]))
       ], cpNormal, True),
       wbMODT
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(DEBR, 'Debris', [
+    wbEDID,
+    wbRArray('Models', wbDebrisModel, cpNormal, True)
   ]);
 
   wbRecord(IMGS, 'Image Space', [
@@ -11416,6 +11438,103 @@ begin
     wbRArrayS('FormIDs', wbFormID(LNAM, 'FormID'), cpNormal, False, nil, nil, nil, wbFLSTLNAMIsSorted)
   ]);
 
+  wbPerkEffect :=
+    wbRStructSK([0, 1], 'Effect', [
+    wbStructSK(PRKE, [1, 2, 0], 'Header', [
+      wbInteger('Type', itU8, wbEnum([
+        'Quest + Stage',
+        'Ability',
+        'Entry Point'
+      ]), cpNormal, False, nil, wbPERKPRKETypeAfterSet),
+      wbInteger('Rank', itU8),
+      wbInteger('Priority', itU8)
+    ]),
+    wbUnion(DATA, 'Effect Data', wbPerkDATADecider, [
+      wbStructSK([0, 1], 'Quest + Stage', [
+        wbFormIDCk('Quest', [QUST]),
+        wbInteger('Quest Stage', itU16, wbPerkDATAQuestStageToStr, wbQuestStageToInt)
+      ]),
+      wbFormIDCk('Ability', [SPEL]),
+      wbStructSK([0, 1], 'Entry Point', [
+        wbInteger('Entry Point', itU8, wbEntryPointsEnum, cpNormal, True, nil{, wbPERKEntryPointAfterSet}),
+        wbInteger('Function', itU8, wbEnum([
+          {0} 'Unknown 0',
+          {1} 'Set Value', // EPFT=1
+          {2} 'Add Value', // EPFT=1
+          {3} 'Multiply Value', // EPFT=1
+          {4} 'Add Range To Value', // EPFT=2
+          {5} 'Add Actor Value Mult', // EPFT=2
+          {6} 'Absolute Value', // no params
+          {7} 'Negative Absolute Value', // no params
+          {8} 'Add Leveled List', // EPFT=3
+          {9} 'Add Activate Choice', // EPFT=4
+         {10} 'Select Spell', // EPFT=5
+         {11} 'Select Text', // EPFT=6
+         {12} 'Set to Actor Value Mult', // EPFT=2
+         {13} 'Multiply Actor Value Mult', // EPFT=2
+         {14} 'Multiply 1 + Actor Value Mult', // EPFT=2
+         {15} 'Set Text' // EPFT=7
+        ])),
+        wbInteger('Perk Condition Tab Count', itU8, nil, cpIgnore)
+      ])
+    ], cpNormal, True),
+
+    wbRStructsSK('Perk Conditions', 'Perk Condition', [0], [
+      wbInteger(PRKC, 'Run On (Tab Index)', itS8{, wbPRKCToStr, wbPRKCToInt}),
+      wbCTDAsReq
+    ], [], cpNormal, False{, nil, nil, wbPERKPRKCDontShow}),
+
+    wbRStruct('Function Parameters', [
+      wbInteger(EPFT, 'Type', itU8, wbEnum([
+        {0} 'None',
+        {1} 'Float',
+        {2} 'Float/AV,Float',
+        {3} 'LVLI',
+        {4} 'SPEL,lstring,flags',
+        {5} 'SPEL',
+        {6} 'string',
+        {7} 'lstring',
+        {8} 'AVIF'
+      ])),
+      // case(EPFT) of
+      // 1: EPFD=float
+      // 2: EPFD=float,float
+      // 3: EPFD=LVLI
+      // 4: EPFD=SPEL, EPF2=lstring, EPF3=int32 flags
+      // 5: EPFD=SPEL
+      // 6: EPFD=string
+      // 7: EPFD=lstring
+
+      wbInteger(EPFB, 'Perk Entry ID (unique)', itU16),
+      wbLString(EPF2, 'Button Label', 0, cpTranslate),
+      // keeping as struct to be similar to tes5 format
+      wbStruct(EPF3, 'Script Flags', [
+        wbInteger('Script Flags', itU16, wbFlags([
+          'Run Immediately',
+          'Replace Default'
+        ]))
+      ]),
+      wbUnion(EPFD, 'Data', wbEPFDDecider, [
+        {0} wbByteArray('Unknown'),
+        {1} wbFloat('Float'),
+        {2} wbStruct('Float, Float', [
+              wbFloat('Float 1'),
+              wbFloat('Float 2')
+            ]),
+        {3} wbFormIDCk('Leveled Item', [LVLI]),
+        {4} wbFormIDCk('Spell', [SPEL]),
+        {5} wbFormIDCk('Spell', [SPEL]),
+        {6} wbString('Text', 0, cpTranslate),
+        {7} wbLString('Text', 0, cpTranslate),
+        {8} wbStruct('Actor Value, Float', [
+              wbActorValue, // wbInteger('Actor Value', itU32, wbEPFDActorValueToStr, wbEPFDActorValueToInt),
+              wbFloat('Float')
+            ])
+      ], cpNormal, False{, wbEPFDDontShow})
+    ], [], cpNormal, False{, wbPERKPRKCDontShow}),
+    wbEmpty(PRKF, 'End Marker', cpIgnore, True)
+  ], []);
+
   wbRecord(PERK, 'Perk',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  2, 'Non-Playable'
@@ -11436,102 +11555,7 @@ begin
     wbFormIDCk(SNAM, 'Sound', [SNDR]),
     wbFormIDCK(NNAM, 'Next Perk', [PERK, NULL]),
     wbString(FNAM, 'SWF'),
-
-    wbRStructsSK('Effects', 'Effect', [0, 1], [
-      wbStructSK(PRKE, [1, 2, 0], 'Header', [
-        wbInteger('Type', itU8, wbEnum([
-          'Quest + Stage',
-          'Ability',
-          'Entry Point'
-        ]), cpNormal, False, nil, wbPERKPRKETypeAfterSet),
-        wbInteger('Rank', itU8),
-        wbInteger('Priority', itU8)
-      ]),
-      wbUnion(DATA, 'Effect Data', wbPerkDATADecider, [
-        wbStructSK([0, 1], 'Quest + Stage', [
-          wbFormIDCk('Quest', [QUST]),
-          wbInteger('Quest Stage', itU16, wbPerkDATAQuestStageToStr, wbQuestStageToInt)
-        ]),
-        wbFormIDCk('Ability', [SPEL]),
-        wbStructSK([0, 1], 'Entry Point', [
-          wbInteger('Entry Point', itU8, wbEntryPointsEnum, cpNormal, True, nil{, wbPERKEntryPointAfterSet}),
-          wbInteger('Function', itU8, wbEnum([
-            {0} 'Unknown 0',
-            {1} 'Set Value', // EPFT=1
-            {2} 'Add Value', // EPFT=1
-            {3} 'Multiply Value', // EPFT=1
-            {4} 'Add Range To Value', // EPFT=2
-            {5} 'Add Actor Value Mult', // EPFT=2
-            {6} 'Absolute Value', // no params
-            {7} 'Negative Absolute Value', // no params
-            {8} 'Add Leveled List', // EPFT=3
-            {9} 'Add Activate Choice', // EPFT=4
-           {10} 'Select Spell', // EPFT=5
-           {11} 'Select Text', // EPFT=6
-           {12} 'Set to Actor Value Mult', // EPFT=2
-           {13} 'Multiply Actor Value Mult', // EPFT=2
-           {14} 'Multiply 1 + Actor Value Mult', // EPFT=2
-           {15} 'Set Text' // EPFT=7
-          ])),
-          wbInteger('Perk Condition Tab Count', itU8, nil, cpIgnore)
-        ])
-      ], cpNormal, True),
-
-      wbRStructsSK('Perk Conditions', 'Perk Condition', [0], [
-        wbInteger(PRKC, 'Run On (Tab Index)', itS8{, wbPRKCToStr, wbPRKCToInt}),
-        wbCTDAsReq
-      ], [], cpNormal, False{, nil, nil, wbPERKPRKCDontShow}),
-
-      wbRStruct('Function Parameters', [
-        wbInteger(EPFT, 'Type', itU8, wbEnum([
-          {0} 'None',
-          {1} 'Float',
-          {2} 'Float/AV,Float',
-          {3} 'LVLI',
-          {4} 'SPEL,lstring,flags',
-          {5} 'SPEL',
-          {6} 'string',
-          {7} 'lstring',
-          {8} 'AVIF'
-        ])),
-        // case(EPFT) of
-        // 1: EPFD=float
-        // 2: EPFD=float,float
-        // 3: EPFD=LVLI
-        // 4: EPFD=SPEL, EPF2=lstring, EPF3=int32 flags
-        // 5: EPFD=SPEL
-        // 6: EPFD=string
-        // 7: EPFD=lstring
-
-        wbInteger(EPFB, 'Perk Entry ID (unique)', itU16),
-        wbLString(EPF2, 'Button Label', 0, cpTranslate),
-        // keeping as struct to be similar to tes5 format
-        wbStruct(EPF3, 'Script Flags', [
-          wbInteger('Script Flags', itU16, wbFlags([
-            'Run Immediately',
-            'Replace Default'
-          ]))
-        ]),
-        wbUnion(EPFD, 'Data', wbEPFDDecider, [
-          {0} wbByteArray('Unknown'),
-          {1} wbFloat('Float'),
-          {2} wbStruct('Float, Float', [
-                wbFloat('Float 1'),
-                wbFloat('Float 2')
-              ]),
-          {3} wbFormIDCk('Leveled Item', [LVLI]),
-          {4} wbFormIDCk('Spell', [SPEL]),
-          {5} wbFormIDCk('Spell', [SPEL]),
-          {6} wbString('Text', 0, cpTranslate),
-          {7} wbLString('Text', 0, cpTranslate),
-          {8} wbStruct('Actor Value, Float', [
-                wbActorValue, // wbInteger('Actor Value', itU32, wbEPFDActorValueToStr, wbEPFDActorValueToInt),
-                wbFloat('Float')
-              ])
-        ], cpNormal, False{, wbEPFDDontShow})
-      ], [], cpNormal, False{, wbPERKPRKCDontShow}),
-      wbEmpty(PRKF, 'End Marker', cpIgnore, True)
-    ], [])
+    wbRArrayS('Effects', wbPerkEffect)
   ]);
 
   wbRecord(BPTD, 'Body Part Data', [
@@ -11997,7 +12021,14 @@ end;
 procedure DefineFO4i;
 var
   a, b, c : TVarRecs;
+  wbMenuButton: IwbRecordMemberDef;
 begin
+  wbMenuButton :=
+    wbRStruct('Menu Button', [
+      wbLStringKC(ITXT, 'Button Text', 0, cpTranslate),
+      wbCTDAs
+    ], []);
+
   wbRecord(MESG, 'Message', [
     wbEDID,
     wbDESCReq,
@@ -12011,10 +12042,7 @@ begin
     wbInteger(TNAM, 'Display Time', itU32, nil, cpNormal, False, False, wbMESGTNAMDontShow),
     wbString(SNAM, 'SWF'),
     wbLStringKC(NNAM, 'Short Title', 0, cpTranslate),
-    wbRStructs('Menu Buttons', 'Menu Button', [
-      wbLStringKC(ITXT, 'Button Text', 0, cpTranslate),
-      wbCTDAs
-    ], [])
+    wbRArray('Menu Buttons', wbMenuButton)
   ], False, nil, cpNormal, False, wbMESGAfterLoad);
 
   a := MakeVarRecs([
@@ -12564,6 +12592,8 @@ begin
 end;
 
 procedure DefineFO4j;
+var
+  wbStartScene: IwbRecordMemberDef;
 begin
   wbRecord(DLBR, 'Dialog Branch', [
     wbEDID,
@@ -12659,6 +12689,15 @@ begin
       wbFormIDCk('Association Type', [ASTP, NULL])
     ])
   ]);
+
+  wbStartScene :=
+    wbRStruct('Start Scene', [
+        wbFormIDCk(LCEP, 'Scene', [SCEN]),
+        wbInteger(INTT, 'Phase Index', itU16),
+        wbString(SSPN, 'Start Phase for Scene'),
+        wbCITC,
+        wbCTDAs
+      ], []);
 
   wbRecord(SCEN, 'Scene', [
     wbEDID,
@@ -12770,13 +12809,7 @@ begin
       wbInteger(SCQS, 'Set Parent Quest Stage', itS16),
       wbFloat(TNAM, 'Timer - Min Seconds'),
       wbUnknown(STSC),
-      wbRStructs('Start Scenes', 'Start Scene', [
-        wbFormIDCk(LCEP, 'Scene', [SCEN]),
-        wbInteger(INTT, 'Phase Index', itU16),
-        wbString(SSPN, 'Start Phase for Scene'),
-        wbCITC,
-        wbCTDAs
-      ], []),
+      wbRArray('Start Scenes', wbStartScene),
       wbFormIDCk(PTOP, 'Player Positive Response', [DIAL]),
       wbFormIDCk(NTOP, 'Player Negative Response', [DIAL]),
       wbFormIDCk(NETO, 'Player Neutral Response', [DIAL]),
@@ -13506,6 +13539,10 @@ begin
 end;
 
 procedure DefineFO4m;
+var
+  wbLeveledListEntryItem: IwbRecordMemberDef;
+  wbLeveledListEntryNPC: IwbRecordMemberDef;
+  wbFaction: IwbRecordMemberDef;
 begin
 
   wbRecord(LSCR, 'Load Screen',
@@ -14132,11 +14169,12 @@ end;
 procedure DefineFO4n;
 
   function wbTintTemplateGroups(const aName: string): IwbSubRecordArrayDef;
+  var
+    wbTintTemplateGroup: IwbSubRecordStructDef;
+    wbTintTemplateOption: IwbSubRecordStructDef;
   begin
-    Result :=
-      wbRStructs(aName, 'Group', [
-        wbLString(TTGP, 'Group Name', 0, cpTranslate),
-        wbRStructs('Options', 'Option', [
+    wbTintTemplateOption :=
+      wbRStruct('Option', [
           wbStruct(TETI, 'Index', [
             wbInteger('Slot', itU16, wbEnum([
               'Forehead Mask',
@@ -14190,9 +14228,16 @@ procedure DefineFO4n;
             ]))
           ])),
           wbFloat(TTED, 'Default')
-        ], []),
+        ], []);
+
+    wbTintTemplateGroup :=
+      wbRStruct('Group', [
+        wbLString(TTGP, 'Group Name', 0, cpTranslate),
+        wbRArray('Options', wbTintTemplateOption),
         wbInteger(TTGE, 'Category Index', itU32)
       ], []);
+
+    Result := wbRArray(aName, wbTintTemplateGroup);
   end;
 
   function wbMorphGroups(const aName: string): IwbSubRecordArrayDef;
@@ -16734,6 +16779,8 @@ begin
 end;
 
 procedure DefineFO4s;
+var
+  wbStaticPart: IwbRecordMemberDef;
 begin
   wbRecord(NOTE, 'Note', [
     wbEDID,
@@ -16866,6 +16913,24 @@ begin
     wbUnknown(VNAM, cpNormal, True)
   ]);
 
+  wbStaticPart :=
+    wbRStructSK([0], 'Part', [
+      wbFormIDCk(ONAM, 'Static', [ACTI, ALCH, AMMO, BOOK, CONT, DOOR, FURN, MISC, MSTT, STAT, TERM, WEAP]),
+      wbArrayS(DATA, 'Placements', wbStruct('Placement', [
+        wbStruct('Position', [
+          wbFloat('X'),
+          wbFloat('Y'),
+          wbFloat('Z')
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
+        wbStruct('Rotation', [
+          wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
+          wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
+          wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
+        wbFloat('Scale')
+      ]), 0, cpNormal, True)
+    ], [], cpNormal, True);
+
   wbRecord(SCOL, 'Static Collection',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  4, 'Non Occluder',
@@ -16884,22 +16949,7 @@ begin
     wbMODL,
     wbFULL,
     wbFLTR,
-    wbRStructsSK('Parts', 'Part', [0], [
-      wbFormIDCk(ONAM, 'Static', [ACTI, ALCH, AMMO, BOOK, CONT, DOOR, FURN, MISC, MSTT, STAT, TERM, WEAP]),
-      wbArrayS(DATA, 'Placements', wbStruct('Placement', [
-        wbStruct('Position', [
-          wbFloat('X'),
-          wbFloat('Y'),
-          wbFloat('Z')
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbStruct('Rotation', [
-          wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbFloat('Scale')
-      ]), 0, cpNormal, True)
-    ], [], cpNormal, True)
+    wbRArrayS('Parts', wbStaticPart, cpNormal, True)
   ]);
 
   wbRecord(SCSN, 'Audio Category Snapshot', [

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -8551,7 +8551,7 @@ begin
     Int64($0F3315AC), 'Money Shots',
     Int64($5E457DAC), 'Most Caps Carried',
     Int64($D37C6909), 'Murders',
-    Int64($B91253A4), 'Mysterious Strabger Visits',
+    Int64($B91253A4), 'Mysterious Stranger Visits',
     Int64($1DEEA18A), 'Nuka Cola Flavors Created',
     Int64($9CE72536), 'Nuka World Creatures Killed',
     Int64($EB0D60AC), 'Objects Built',
@@ -8576,7 +8576,7 @@ begin
     Int64($ACE470D7), 'Skill Books Read',
     Int64($B556CC52), 'Sneak Attacks',
     Int64($32D1B38F), 'Speach Successes',
-    Int64($5D6B18F1), 'Stimpacks Taken',
+    Int64($5D6B18F1), 'Stimpaks Taken',
     Int64($C5321BC5), 'Supply Lines Created',
     Int64($3869002E), 'Survival Denied',
     Int64($F9DEC209), 'Survival Level-Ups',
@@ -10188,7 +10188,7 @@ begin
        {110} 'OutofBreath',
        {111} 'CombatGrunt',
        {112} 'LeaveWaterBreath',
-       {113} 'ImpatientPostitive',
+       {113} 'ImpatientPositive',
        {114} 'ImpatientNegative',
        {115} 'ImpatientNeutral',
        {116} 'ImpatientQuestion',
@@ -10749,7 +10749,7 @@ begin
     wbEDID,
     wbOBNDReq,
     wbRStruct('Textures (RGB/A)', [
-      wbString(TX00, 'Difuse'),
+      wbString(TX00, 'Diffuse'),
       wbString(TX01, 'Normal/Gloss'),
       wbString(TX03, 'Glow'),
       wbString(TX04, 'Height'),
@@ -12254,7 +12254,7 @@ begin
     Sig2Int('HBEC'), 'Help Basic Enchanting',
     Sig2Int('HBFG'), 'Help Basic Forging',
     Sig2Int('HBFS'), 'Help Favorites',
-    Sig2Int('HBFT'), 'Help Teamate Favor',
+    Sig2Int('HBFT'), 'Help Teammate Favor',
     Sig2Int('HBHJ'), 'Help Jail',
     Sig2Int('HBJL'), 'Help Journal',
     Sig2Int('HBLH'), 'Help Low Health',
@@ -13350,7 +13350,7 @@ begin
       ]), [18]), [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -13390,7 +13390,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)
@@ -13648,7 +13648,7 @@ begin
     {28} 'Cure Addiction',
     {29} 'Cure Poison',
     {30} 'Concussion',
-    {31} 'Stimpack',
+    {31} 'Stimpak',
     {32} 'Accumulate Magnitude',
     {33} 'Stagger',
     {34} 'Peak Value Modifier',

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -1196,7 +1196,7 @@ var
   wbKWDAs: IwbSubRecordDef;
   wbReqKWDAs: IwbSubRecordDef;
   wbKeywords: IwbSubRecordStructDef;
-  wbCNAM: IwbSubRecordDef;
+  wbCNAM: IwbRecordMemberDef;
   wbCITC: IwbSubRecordDef;
   wbCITCReq: IwbSubRecordDef;
   wbMGEFData: IwbSubRecordStructDef;
@@ -6525,23 +6525,23 @@ begin
     Result := 7;
 end;
 
-function wbByteColors(const aName: string = 'Color'): IwbStructDef;
+function wbByteColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbInteger('Red', itU8),
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unused', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
-function wbFloatColors(const aName: string = 'Color'): IwbStructDef;
+function wbFloatColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbFloat('Red', cpNormal, True, 255, 0),
     wbFloat('Green', cpNormal, True, 255, 0),
     wbFloat('Blue', cpNormal, True, 255, 0)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
 function wbWeatherColors(const aName: string): IwbStructDef;
@@ -7256,7 +7256,7 @@ begin
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unknown', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 
   wbDODT := wbStruct(DODT, 'Decal Data', [
     wbFloat('Unknown'),
@@ -8181,12 +8181,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -8195,12 +8195,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMODS := wbFormIDCk(MODS, 'Material Swap', [MSWP]);
@@ -8578,7 +8578,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]), -1).IncludeFlag(dfNotAlignable),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable),
       wbArray('Triangles',
         wbStruct('Triangle', [
           wbInteger('Vertex 0', itS16, wbVertexToStr0, wbVertexToInt0).SetLinksToCallback(wbVertexLinksTo),
@@ -10193,7 +10193,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(SNAM, 'Sound - Looping', [SNDR]),
     wbFormIDCk(VNAM, 'Sound - Activation', [SNDR]),
     wbFormIDCk(WNAM, 'Water Type', [WATR]),
@@ -12147,7 +12147,7 @@ begin
                 wbFloat('X'),
                 wbFloat('Y'),
                 wbFloat('Z')
-              ]), -1)
+              ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1)
             ])
           ]),
           wbByteArray('Unknown', 4),
@@ -12902,7 +12902,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True, nil, 9),
     wbFormIDCk(MNAM, 'Image Space Modifier', [IMAD])
   ]);
@@ -12941,7 +12941,7 @@ begin
       wbFloat('Red', cpNormal, True, 255, 0),
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFloat(BNAM, 'Buoyancy'),
     wbInteger(FNAM, 'Flags', itU32, wbFlags([
       'Stair Material',
@@ -14073,7 +14073,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbFloat('Normal Dampener'),
       wbFloatColors('Single Pass Color'),
       wbInteger('Flags', itU32, wbFlags(['Single Pass']))
@@ -14245,7 +14245,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbInteger(GNAM, 'Flags', itU32, wbFlags([
       {0x00000001} 'Trigger Volume',
       {0x00000002} 'Sensor',
@@ -14587,7 +14587,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -14601,7 +14601,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -15402,7 +15402,7 @@ begin
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0),
       wbFloat('Alpha')
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbArray(MSDK, 'Morph Keys', wbInteger('Key', itU32, wbMorphValueToStr, wbHexStrToInt)),
     wbArray(MSDV, 'Morph Values', wbFloat('Value')),
     wbRArrayS('Face Tinting Layers',
@@ -16531,7 +16531,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
 
     {--- Primitive ---}
     wbStruct(XPRM, 'Primitive', [
@@ -16539,7 +16539,7 @@ begin
         wbFloat('X', cpNormal, True, 2, 4),
         wbFloat('Y', cpNormal, True, 2, 4),
         wbFloat('Z', cpNormal, True, 2, 4)
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbFloatColors('Color'),
       wbFloat('Unknown'),
       wbInteger('Type', itU32, wbEnum([
@@ -16567,7 +16567,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -16587,7 +16587,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -16991,7 +16991,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unknown', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
     wbFormIDCkNoReach(LNAM, 'Location', [LCTN]),
     wbUnknown(LCPR),
@@ -17512,12 +17512,12 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbStruct(NAM1, 'Angular Velocity', [
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbString(NAM2, 'Layer 1 Noise Texture'),
     wbString(NAM3, 'Layer 2 Noise Texture'),
     wbString(NAM4, 'Layer 3 Noise Texture'),
@@ -17940,7 +17940,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Visual Effect - Begin', itU8), // scaled 0..1
       wbInteger('Visual Effect - End', itU8), // scaled 0..1
       wbInteger('Wind Direction', itU8), // scaled 0..360
@@ -18487,12 +18487,12 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbStruct('Rotation', [
           wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
     ], [], cpNormal, True)
@@ -18658,7 +18658,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbUnion('Unknown', wbDeciderFormVersion187, [
         wbEmpty('Unused'),
         wbFloat('Unknown')

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -9267,7 +9267,7 @@ begin
     Int64($0F3315AC), 'Money Shots',
     Int64($5E457DAC), 'Most Caps Carried',
     Int64($D37C6909), 'Murders',
-    Int64($B91253A4), 'Mysterious Strabger Visits',
+    Int64($B91253A4), 'Mysterious Stranger Visits',
     Int64($1DEEA18A), 'Nuka Cola Flavors Created',
     Int64($9CE72536), 'Nuka World Creatures Killed',
     Int64($EB0D60AC), 'Objects Built',
@@ -9292,7 +9292,7 @@ begin
     Int64($ACE470D7), 'Skill Books Read',
     Int64($B556CC52), 'Sneak Attacks',
     Int64($32D1B38F), 'Speach Successes',
-    Int64($5D6B18F1), 'Stimpacks Taken',
+    Int64($5D6B18F1), 'Stimpaks Taken',
     Int64($C5321BC5), 'Supply Lines Created',
     Int64($3869002E), 'Survival Denied',
     Int64($F9DEC209), 'Survival Level-Ups',
@@ -11188,7 +11188,7 @@ begin
        {110} 'OutofBreath',
        {111} 'CombatGrunt',
        {112} 'LeaveWaterBreath',
-       {113} 'ImpatientPostitive',
+       {113} 'ImpatientPositive',
        {114} 'ImpatientNegative',
        {115} 'ImpatientNeutral',
        {116} 'ImpatientQuestion',
@@ -11792,7 +11792,7 @@ begin
     wbOPDSs,
     wbFLTR,
     wbRStruct('Textures (RGB/A)', [
-      wbString(TX00, 'Difuse'),
+      wbString(TX00, 'Diffuse'),
       wbString(TX01, 'Normal/Gloss'),
       wbString(TX03, 'Glow'),
       wbString(TX04, 'Height'),
@@ -13409,7 +13409,7 @@ begin
     Sig2Int('HBEC'), 'Help Basic Enchanting',
     Sig2Int('HBFG'), 'Help Basic Forging',
     Sig2Int('HBFS'), 'Help Favorites',
-    Sig2Int('HBFT'), 'Help Teamate Favor',
+    Sig2Int('HBFT'), 'Help Teammate Favor',
     Sig2Int('HBHJ'), 'Help Jail',
     Sig2Int('HBJL'), 'Help Journal',
     Sig2Int('HBLH'), 'Help Low Health',
@@ -14549,7 +14549,7 @@ begin
       ]), [18]), [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -14589,7 +14589,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)
@@ -14968,7 +14968,7 @@ begin
     {28} 'Cure Addiction',
     {29} 'Cure Poison',
     {30} 'Concussion',
-    {31} 'Stimpack',
+    {31} 'Stimpak',
     {32} 'Accumulate Magnitude',
     {33} 'Stagger',
     {34} 'Peak Value Modifier',

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -1284,11 +1284,6 @@ var
   wbLVOC: IwbSubRecordDef;
   wbLVIG: IwbSubRecordDef;
   wbXPCK: IwbSubRecordDef;
-  wbFaction: IwbRecordMemberDef;
-  wbLeveledListEntryItem: IwbRecordMemberDef;
-  wbLeveledListEntryNPC: IwbRecordMemberDef;
-  wbLeveledListEntryPackIn: IwbRecordMemberDef;
-  wbLeveledListEntryPerkCard: IwbRecordMemberDef;
 
 function Sig2Int(aSignature: TwbSignature): Cardinal; inline;
 begin
@@ -8709,6 +8704,9 @@ Can't properly represent that with current record definition methods.
 end;
 
 procedure DefineFO76b;
+var
+  wbBoneDataItem: IwbRecordMemberDef;
+  wbEffect: IwbRecordMemberDef;
 begin
   wbRefRecord(ACHR, 'Placed NPC',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -10121,20 +10119,23 @@ begin
     wbEmpty(STOP, 'Marker', cpNormal, True)
   ], []);
 
-  wbBSMPSequence := wbRStructs('Bone Data', 'Data', [
-    wbInteger(BSMP, 'Gender', itU32, wbEnum(['Male', 'Female'])),
-    // should not be sorted!!!
-    wbRArray('Bones',
-      wbRStructSK([0], 'Bone', [
-        wbString(BSMB, 'Name'),
-        wbArray(BSMS, 'Values', wbFloat('Value')).IncludeFlag(dfNotAlignable),
-        wbUnknown(BMMP)
-      ], [])
-    )
-  ], []);
+  wbBoneDataItem :=
+    wbRStruct('Data', [
+      wbInteger(BSMP, 'Gender', itU32, wbEnum(['Male', 'Female'])),
+      // should not be sorted!!!
+      wbRArray('Bones',
+        wbRStructSK([0], 'Bone', [
+          wbString(BSMB, 'Name'),
+          wbArray(BSMS, 'Values', wbFloat('Value')).IncludeFlag(dfNotAlignable),
+          wbUnknown(BMMP)
+        ], [])
+      )
+    ], []);
 
-  wbEffectsReq :=
-    wbRStructs('Effects', 'Effect', [
+  wbBSMPSequence := wbRArray('Bone Data', wbBoneDataItem);
+
+  wbEffect :=
+    wbRStruct('Effect', [
       wbEFID,
       wbEFIT,
       wbFormIDCk(CVT0, 'Curve Table', [CURV]),
@@ -10144,6 +10145,9 @@ begin
       wbFormIDCk(DURG, 'Duration', [GLOB]),
       wbFormIDCk(MAGG, 'Magnitude', [GLOB])
     ], [], cpNormal, True);
+
+  wbEffectsReq :=
+    wbRArray('Effects', wbEffect, cpNormal, True);
 
   wbRecord(ACTI, 'Activator',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -10587,6 +10591,8 @@ procedure DefineFO76c;
       wbString(MNAM, 'Comments')
     ], True, wbPlacedAddInfo);
   end;
+var
+  wbCellFlags: IwbFlagsDef;
 
 begin
 {>>>
@@ -10609,7 +10615,7 @@ begin
   ReferenceRecord(PHZD, 'Placed Hazard');
   ReferenceRecord(PMIS, 'Placed Missile');
 
-  var wbCellFlags := wbFlags([
+  wbCellFlags := wbFlags([
       {0x0001} 'Is Interior Cell',
       {0x0002} 'Has Water',
       {0x0004} 'Can''t Travel From Here',
@@ -11762,6 +11768,8 @@ begin
 end;
 
 procedure DefineFO76e;
+var
+  wbHeadPartPart: IwbRecordMemberDef;
 begin
   wbRecord(LCRT, 'Location Reference Type',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -11814,6 +11822,16 @@ begin
     wbString(MNAM, 'Material')
   ]);
 
+  wbHeadPartPart :=
+    wbRStruct('Part', [
+      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
+        'Race Morph',
+        'Tri',
+        'Chargen Morph'
+      ])),
+      wbString(NAM1, 'FileName', 0, cpTranslate, True)
+    ], []);
+
   wbRecord(HDPT, 'Head Part',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  2, 'Non-Playable'
@@ -11845,14 +11863,7 @@ begin
     wbRArrayS('Extra Parts',
       wbFormIDCk(HNAM, 'Part', [HDPT])
     ),
-    wbRStructs('Parts', 'Part', [
-      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
-        'Race Morph',
-        'Tri',
-        'Chargen Morph'
-      ])),
-      wbString(NAM1, 'FileName', 0, cpTranslate, True)
-    ], []),
+    wbRArray('Parts', wbHeadPartPart),
     wbFormIDCk(TNAM, 'Texture Set', [TXST]),
     wbFormIDCk(CNAM, 'Color', [CLFM]),
     wbFormIDCk(RNAM, 'Valid Races', [FLST]),
@@ -12188,6 +12199,8 @@ begin
 end;
 
 procedure DefineFO76g;
+var
+  wbDebrisModel: IwbRecordMemberDef;
 begin
 
    wbRecord(EXPL, 'Explosion', [
@@ -12287,9 +12300,8 @@ begin
     ], cpNormal, True, nil, 13)
   ]);
 
-  wbRecord(DEBR, 'Debris', [
-    wbEDID,
-    wbRStructs('Models', 'Model', [
+  wbDebrisModel :=
+    wbRStruct('Model', [
       wbStruct(DATA, 'Data', [
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
@@ -12298,7 +12310,11 @@ begin
         ]))
       ], cpNormal, True),
       wbMODT
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(DEBR, 'Debris', [
+    wbEDID,
+    wbRArray('Models', wbDebrisModel)
   ]);
 
   wbRecord(IMGS, 'Image Space', [
@@ -13150,7 +13166,14 @@ end;
 procedure DefineFO76i;
 var
   a, b, c : TVarRecs;
+  wbMenuButton: IwbRecordMemberDef;
 begin
+  wbMenuButton :=
+    wbRStruct('Menu Button', [
+      wbLStringKC(ITXT, 'Button Text', 0, cpTranslate),
+      wbCTDAs
+    ], []);
+
   wbRecord(MESG, 'Message', [
     wbEDID,
     wbDESCReq,
@@ -13165,10 +13188,7 @@ begin
     wbInteger(TNAM, 'Display Time', itU32, nil, cpNormal, False, False, wbMESGTNAMDontShow),
     wbString(SNAM, 'SWF'),
     wbLStringKC(NNAM, 'Short Title', 0, cpTranslate),
-    wbRStructs('Menu Buttons', 'Menu Button', [
-      wbLStringKC(ITXT, 'Button Text', 0, cpTranslate),
-      wbCTDAs
-    ], []),
+    wbRArray('Menu Buttons', wbMenuButton),
     wbUnknown(MBNR)
   ], False, nil, cpNormal, False, wbMESGAfterLoad);
 
@@ -13723,6 +13743,8 @@ begin
 end;
 
 procedure DefineFO76j;
+var
+  wbStartScene: IwbRecordMemberDef;
 begin
   wbRecord(DLBR, 'Dialog Branch', [
     wbEDID,
@@ -13818,6 +13840,15 @@ begin
       wbFormIDCk('Association Type', [ASTP, NULL])
     ])
   ]);
+
+  wbStartScene :=
+    wbRStruct('Start Scene', [
+      wbFormIDCk(LCEP, 'Scene', [SCEN]),
+      wbInteger(INTT, 'Phase Index', itU16),
+      wbString(SSPN, 'Start Phase for Scene'),
+      wbCITC,
+      wbCTDAs
+    ], []);
 
   wbRecord(SCEN, 'Scene', [
     wbEDID,
@@ -13930,13 +13961,7 @@ begin
       wbInteger(SCQS, 'Set Parent Quest Stage', itS16),
       wbFloat(TNAM, 'Timer - Min Seconds'),
       wbUnknown(STSC),
-      wbRStructs('Start Scenes', 'Start Scene', [
-        wbFormIDCk(LCEP, 'Scene', [SCEN]),
-        wbInteger(INTT, 'Phase Index', itU16),
-        wbString(SSPN, 'Start Phase for Scene'),
-        wbCITC,
-        wbCTDAs
-      ], []),
+      wbRArray('Start Scenes', wbStartScene),
       wbFormIDCk(PTOP, 'Player Positive Response', [DIAL]),
       wbFormIDCk(NTOP, 'Player Negative Response', [DIAL]),
       wbFormIDCk(NETO, 'Player Neutral Response', [DIAL]),
@@ -14711,6 +14736,11 @@ begin
 end;
 
 procedure DefineFO76m;
+var
+  wbLeveledListEntryItem: IwbRecordMemberDef;
+  wbLeveledListEntryNPC: IwbRecordMemberDef;
+  wbLeveledListEntryPackIn: IwbRecordMemberDef;
+  wbFaction: IwbRecordMemberDef;
 begin
 
   wbRecord(LSCR, 'Load Screen',
@@ -15511,30 +15541,38 @@ end;
 procedure DefineFO76n;
 
   function wbTintTemplateGroups(const aName: string): IwbSubRecordArrayDef;
+  var
+    wbTintTemplateGroup: IwbSubRecordStructDef;
+    wbTintTemplateOption: IwbSubRecordStructDef;
   begin
-    Result :=
-      wbRStructs(aName, 'Group', [
+    wbTintTemplateOption :=
+      wbRStruct('Option', [
+        wbStruct(TETI, 'Index', [
+          wbByteArray('Unknown', 2),
+          wbInteger('Index', itU16)
+        ]),
+        wbLString(TTGP, 'Name', 0, cpTranslate),
+        wbUnknown(TTEF),
+        wbCTDAs,
+        wbRArray('Textures', wbString(TTET, 'Texture')),
+        wbUnknown(TTEB),
+        wbArray(TTEC, 'Template Colors', wbStruct('Template Color', [
+          wbFormIDCk('Color', [CLFM]),
+          wbFloat('Alpha'),
+          wbInteger('Template Index', itU16),
+          wbByteArray('Unknown', 4)
+        ])),
+        wbFloat(TTED, 'Unknown')
+      ], []);
+
+    wbTintTemplateGroup :=
+      wbRStruct('Group', [
         wbLString(TTGP, 'Group Name', 0, cpTranslate),
-        wbRStructs('Options', 'Option', [
-          wbStruct(TETI, 'Index', [
-            wbByteArray('Unknown', 2),
-            wbInteger('Index', itU16)
-          ]),
-          wbLString(TTGP, 'Name', 0, cpTranslate),
-          wbUnknown(TTEF),
-          wbCTDAs,
-          wbRArray('Textures', wbString(TTET, 'Texture')),
-          wbUnknown(TTEB),
-          wbArray(TTEC, 'Template Colors', wbStruct('Template Color', [
-            wbFormIDCk('Color', [CLFM]),
-            wbFloat('Alpha'),
-            wbInteger('Template Index', itU16),
-            wbByteArray('Unknown', 4)
-          ])),
-          wbFloat(TTED, 'Unknown')
-        ], []),
+        wbRArray('Options', wbTintTemplateOption),
         wbByteArray(TTGE, 'Group End', 4)
       ], []);
+
+    Result := wbRArray(aName, wbTintTemplateGroup);
   end;
 
   function wbMorphGroups(const aName: string): IwbSubRecordArrayDef;
@@ -18303,6 +18341,8 @@ begin
 end;
 
 procedure DefineFO76s;
+var
+  wbStaticPart: IwbRecordMemberDef;
 begin
   wbRecord(NOTE, 'Note', [
     wbEDID,
@@ -18452,6 +18492,28 @@ begin
     wbUnknown(VNAM, cpNormal, True)
   ]);
 
+  wbStaticPart :=
+    wbRStruct('Part', [
+      wbStruct(ONAM, 'Static', [
+        wbFormIDCk('Static', [ACTI, ALCH, AMMO, BOOK, CONT, DOOR, FURN, MISC, MSTT, STAT, TERM, WEAP, CNCY, SCOL]),
+        wbFormIDCk('Material Swap', [MSWP])
+      ]),
+      wbUnknown(ONAM),
+      wbArrayS(DATA, 'Placements', wbStruct('Placement', [
+        wbStruct('Position', [
+          wbFloat('X'),
+          wbFloat('Y'),
+          wbFloat('Z')
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
+        wbStruct('Rotation', [
+          wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
+          wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
+          wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
+        wbFloat('Scale')
+      ]), 0, cpNormal, True)
+    ], [], cpNormal, True);
+
   wbRecord(SCOL, 'Static Collection',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  4, 'Non Occluder',
@@ -18476,26 +18538,7 @@ begin
     wbNAM1LODP,
     wbPRPS,
     wbFLTR,
-    wbRStructs('Parts', 'Part', [
-      wbStruct(ONAM, 'Static', [
-        wbFormIDCk('Static', [ACTI, ALCH, AMMO, BOOK, CONT, DOOR, FURN, MISC, MSTT, STAT, TERM, WEAP, CNCY, SCOL]),
-        wbFormIDCk('Material Swap', [MSWP])
-      ]),
-      wbUnknown(ONAM),
-      wbArrayS(DATA, 'Placements', wbStruct('Placement', [
-        wbStruct('Position', [
-          wbFloat('X'),
-          wbFloat('Y'),
-          wbFloat('Z')
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbStruct('Rotation', [
-          wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbFloat('Scale')
-      ]), 0, cpNormal, True)
-    ], [], cpNormal, True)
+    wbRArray('Parts', wbStaticPart, cpNormal, True)
   ]);
 
   wbRecord(SCSN, 'Audio Category Snapshot', [
@@ -18678,6 +18721,8 @@ end;
 // AAPD\WTMX is always either 00 00 00 00 or 00 00 80 3F
 
 procedure DefineFO76u;
+var
+  wbLeveledListEntryPerkCard: IwbRecordMemberDef;
 begin
   wbRecord(AAPD, 'Aim Assist Pose Data', [
     wbEDID,

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -2047,12 +2047,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -2061,12 +2061,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMODL :=
@@ -2576,19 +2576,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Directional Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Fog Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fog Near'),
       wbFloat('Fog Far'),
       wbInteger('Directional Rotation XY', itS32),
@@ -3043,7 +3043,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Fill/Texture Effect - Alpha Fade In Time'),
       wbFloat('Fill/Texture Effect - Full Alpha Time'),
       wbFloat('Fill/Texture Effect - Alpha Fade Out Time'),
@@ -3058,7 +3058,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Edge Effect - Alpha Fade In Time'),
       wbFloat('Edge Effect - Full Alpha Time'),
       wbFloat('Edge Effect - Alpha Fade Out Time'),
@@ -3096,19 +3096,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 2 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Color Key 3 - Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbFloat('Color Key 1 - Color Alpha'),
       wbFloat('Color Key 2 - Color Alpha'),
       wbFloat('Color Key 3 - Color Alpha'),
@@ -3715,7 +3715,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -3729,7 +3729,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -3775,7 +3775,7 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbInteger('Unused', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Flags', itU32, wbFlags([
         {0x00000001} 'Dynamic',
         {0x00000002} 'Can be Carried',
@@ -4154,7 +4154,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(ZNAM, 'Combat Style', [CSTY]),
     wbFaceGen,
     wbByteArray(FNAM, 'Unknown', 0, cpBenign)
@@ -4548,7 +4548,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unused', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
 
     wbRArray('Region Areas', wbRStruct('Region Area', [
@@ -4613,7 +4613,7 @@ begin
           wbInteger('X', itU16),
           wbInteger('Y', itU16),
           wbInteger('Z', itU16)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbByteArray('Unused', 2),
         wbByteArray('Unknown', 4)
       ])),
@@ -4661,7 +4661,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]), 0, nil, nil, cpNormal, True)
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 0, nil, nil, cpNormal, True)
   ]);
 
   wbRecord(SBSP, 'Subspace', [
@@ -4670,7 +4670,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, True)
+    ], cpNormal, True).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
   ]);
 
   wbSLSD := wbStructSK(SLSD, [0], 'Local Variable Data', [
@@ -4912,19 +4912,19 @@ begin
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Deep Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbStruct('Reflection Color', [
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8),
         wbByteArray('Unused', 1)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Texture Blend', itU8),
       wbByteArray('Unused', 3),
       wbFloat('Rain Simulator - Force'),
@@ -5082,7 +5082,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbByteArray('Unused', 1)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         ['Sunrise', 'Day', 'Sunset', 'Night']
       ),
       ['Sky-Upper','Fog','Clouds-Lower','Ambient','Sunlight','Sun','Stars','Sky-Lower','Horizon','Clouds-Upper']
@@ -5126,7 +5126,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ])
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA)
     ], cpNormal, True),
     wbRArray('Sounds', wbStruct(SNAM, 'Sound', [
       wbFormIDCk('Sound', [SOUN]),

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -3676,7 +3676,7 @@ begin
     wbRecord(LAND, 'Landscape', [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -3717,7 +3717,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -2117,7 +2117,7 @@ begin
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32),
       wbXGLB
-    ], []),
+    ], []).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
     wbXESP,
     wbXRGD,
     wbXSCL,
@@ -2605,7 +2605,7 @@ begin
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32),
       wbXGLB
-    ], [XCLW, XCMT, XCCM])
+    ], [XCLW, XCMT, XCCM]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions)
   ], True, wbCellAddInfo, cpNormal, False, wbCELLAfterLoad);
 
   wbServiceFlags :=
@@ -4481,7 +4481,7 @@ begin
       wbXOWN,
       wbInteger(XRNK, 'Faction rank', itS32),
       wbXGLB
-    ], [XLOC]),
+    ], [XLOC]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions),
     wbXESP,
     wbFormIDCk(XTRG, 'Target', [REFR, ACHR, ACRE], True),
     wbStruct(XSED, 'SpeedTree', [

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -831,10 +831,6 @@ var
   wbOFST: IwbSubRecordDef;
   wbNVNM: IwbSubRecordDef;
   wbNAVIslandData: IwbStructDef;
-  wbFaction: IwbRecordMemberDef;
-  wbLeveledListEntryNPC: IwbRecordMemberDef;
-  wbLeveledListEntryItem: IwbRecordMemberDef;
-  wbLeveledListEntrySpell: IwbRecordMemberDef;
 
 
 function IsSSE: Boolean; inline; overload;
@@ -6170,6 +6166,8 @@ begin
 end;
 
 procedure DefineTES5b;
+var
+  wbEffect: IwbRecordMemberDef;
 begin
 
   wbRefRecord(ACHR, 'Placed NPC',
@@ -7065,12 +7063,15 @@ begin
   wbYNAM := wbFormIDCk(YNAM, 'Sound - Pick Up', [SNDR]);
   wbZNAM := wbFormIDCk(ZNAM, 'Sound - Put Down', [SNDR]);
 
-  wbEffectsReq :=
-    wbRStructs('Effects', 'Effect', [
+  wbEffect :=
+    wbRStruct('Effect', [
       wbEFID,
       wbEFIT,
       wbCTDAs
     ], [], cpNormal, True);
+
+  wbEffectsReq :=
+    wbRArray('Effects', wbEffect, cpNormal, True);
 
   wbRecord(ALCH, 'Ingestible',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
@@ -8357,6 +8358,8 @@ begin
 end;
 
 procedure DefineTES5e;
+var
+  wbHeadPartPart: IwbRecordMemberDef;
 begin
   wbRecord(LCRT, 'Location Reference Type', [
     wbEDID,
@@ -8389,6 +8392,16 @@ begin
     ]), cpNormal, False)
   ]);
 
+  wbHeadPartPart :=
+    wbRStruct('Part', [
+      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
+        'Race Morph',
+        'Tri',
+        'Chargen Morph'
+      ])),
+      wbString(NAM1, 'FileName', 0, cpTranslate, True)
+    ], []);
+
   wbRecord(HDPT, 'Head Part',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00000004}  2, 'Non-Playable'
@@ -8415,14 +8428,7 @@ begin
     wbRArrayS('Extra Parts',
       wbFormIDCk(HNAM, 'Part', [HDPT])
     ),
-    wbRStructs('Parts', 'Part', [
-      wbInteger(NAM0, 'Part Type', itU32, wbEnum([
-        'Race Morph',
-        'Tri',
-        'Chargen Morph'
-      ])),
-      wbString(NAM1, 'FileName', 0, cpTranslate, True)
-    ], []),
+    wbRArray('Parts', wbHeadPartPart),
     wbFormIDCk(TNAM, 'Texture Set', [TXST, NULL]),
     wbFormIDCk(CNAM, 'Color', [CLFM, NULL]),
     wbFormIDCk(RNAM, 'Valid Races', [FLST, NULL])
@@ -8838,6 +8844,8 @@ Can't properly represent that with current record definition methods.
 end;
 
 procedure DefineTES5g;
+var
+  wbDebrisModel: IwbRecordMemberDef;
 begin
 
    wbRecord(EXPL, 'Explosion', [
@@ -8875,9 +8883,8 @@ begin
     ], cpNormal, True, nil, 10)
   ]);
 
-  wbRecord(DEBR, 'Debris', [
-    wbEDID,
-    wbRStructs('Models', 'Model', [
+  wbDebrisModel :=
+    wbRStruct('Model', [
       wbStruct(DATA, 'Data', [
         wbInteger('Percentage', itU8),
         wbString('Model FileName'),
@@ -8886,7 +8893,11 @@ begin
         ]))
       ], cpNormal, True),
       wbMODT
-    ], [], cpNormal, True)
+    ], [], cpNormal, True);
+
+  wbRecord(DEBR, 'Debris', [
+    wbEDID,
+    wbRArray('Models', wbDebrisModel, cpNormal, True)
   ]);
 
   wbRecord(IMGS, 'Image Space', [
@@ -9601,6 +9612,7 @@ procedure DefineTES5i;
 var
   a, b, c : TVarRecs;
   s: string;
+  wbMenuButton: IwbRecordMemberDef;
 begin
   // load map markes list from external file if present
   s := ExtractFilePath(ParamStr(0)) + wbAppName + 'MapMarkers.txt';
@@ -9693,6 +9705,12 @@ begin
      {11} 'DLC02 - Dragonborn'
     ]);
 
+  wbMenuButton :=
+    wbRStruct('Menu Button', [
+      wbLString(ITXT, 'Button Text', 0, cpTranslate),
+      wbCTDAs
+    ], []);
+
   wbRecord(MESG, 'Message', [
     wbEDID,
     wbDESCReq,
@@ -9704,10 +9722,7 @@ begin
       'Auto Display'
     ]), cpNormal, True, False, nil, wbMESGDNAMAfterSet),
     wbInteger(TNAM, 'Display Time', itU32, nil, cpNormal, False, False, wbMESGTNAMDontShow),
-    wbRStructs('Menu Buttons', 'Menu Button', [
-      wbLString(ITXT, 'Button Text', 0, cpTranslate),
-      wbCTDAs
-    ], [])
+    wbRArray('Menu Buttons', wbMenuButton)
   ], False, nil, cpNormal, False, wbMESGAfterLoad);
 
   a := MakeVarRecs([
@@ -11086,6 +11101,11 @@ begin
 end;
 
 procedure DefineTES5m;
+var
+  wbLeveledListEntryItem: IwbRecordMemberDef;
+  wbLeveledListEntryNPC: IwbRecordMemberDef;
+  wbLeveledListEntrySpell: IwbRecordMemberDef;
+  wbFaction: IwbRecordMemberDef;
 begin
 
   wbRecord(LSCR, 'Load Screen',
@@ -14028,6 +14048,8 @@ end;
 
 {>>> Unused records, they have empty GRUP in skyrim.esm <<<}
 procedure DefineTES5p;
+var
+  wbStaticPart: IwbRecordMemberDef;
 begin
   wbRecord(CLDC, 'CLDC', [
     wbEDID
@@ -14051,22 +14073,7 @@ begin
     wbEDID,
     wbOBNDReq,
     wbMODLReq,
-    wbRStructs('Parts', 'Part', [
-      wbFormIDCk(ONAM, 'Static', [STAT]),
-      wbArrayS(DATA, 'Placements', wbStruct('Placement', [
-        wbStruct('Position', [
-          wbFloat('X'),
-          wbFloat('Y'),
-          wbFloat('Z')
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbStruct('Rotation', [
-          wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
-          wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
-        wbFloat('Scale')
-      ]), 0, cpNormal, True)
-    ], [], cpNormal, True)
+    wbRArray('Parts', wbStaticPart, cpNormal, True)
   ]);
 
   wbRecord(SCPT, 'SCPT', [

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -791,8 +791,8 @@ var
   wbKWDAs: IwbSubRecordDef;
   wbReqKWDAs: IwbSubRecordDef;
   wbKeywords: IwbSubRecordStructDef;
-  wbCNAM: IwbSubRecordDef;
-  wbCNAMReq: IwbSubRecordDef;
+  wbCNAM: IwbRecordMemberDef;
+  wbCNAMReq: IwbRecordMemberDef;
   wbCITC: IwbSubRecordDef;
   wbCITCReq: IwbSubRecordDef;
   wbMGEFData: IwbSubRecordStructDef;
@@ -4739,23 +4739,23 @@ begin
     Result := 7;
 end;
 
-function wbByteColors(const aName: string = 'Color'): IwbStructDef;
+function wbByteColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbInteger('Red', itU8),
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unused', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
-function wbFloatColors(const aName: string = 'Color'): IwbStructDef;
+function wbFloatColors(const aName: string = 'Color'): IwbValueDef;
 begin
   Result := wbStruct(aName, [
     wbFloat('Red', cpNormal, True, 255, 0),
     wbFloat('Green', cpNormal, True, 255, 0),
     wbFloat('Blue', cpNormal, True, 255, 0)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
 
 function wbWeatherColors(const aName: string): IwbStructDef;
@@ -5167,13 +5167,13 @@ begin
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unknown', 1)
-  ]);
+  ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
   wbCNAMReq := wbStruct(CNAM, 'Color', [
     wbInteger('Red', itU8),
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbByteArray('Unknown', 1)
-  ], cpNormal, True);
+  ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA);
 
   wbDODT := wbStruct(DODT, 'Decal Data', [
     wbFloat('Min Width'),
@@ -5882,12 +5882,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ]);
 
   wbDATAPosRot :=
@@ -5896,12 +5896,12 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation', [
         wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
         wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-      ])
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
     ], cpNormal, True);
 
   wbMO2S :=
@@ -6299,7 +6299,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFormIDCk(SNAM, 'Sound - Looping', [SNDR]),
     wbFormIDCk(VNAM, 'Sound - Activation', [SNDR]),
     wbFormIDCk(WNAM, 'Water Type', [WATR]),
@@ -8650,7 +8650,7 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]), -1).IncludeFlag(dfNotAlignable),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable),
         wbArray('Triangles',
           wbStruct('Triangle', [
             wbInteger('Vertex 0', itS16, wbVertexToStr0, wbVertexToInt0).SetLinksToCallback(wbVertexLinksTo),
@@ -8789,7 +8789,7 @@ Can't properly represent that with current record definition methods.
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]), -1).IncludeFlag(dfNotAlignable)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable)
       ]);
 
   wbRecord(NAVI, 'Navigation Mesh Info Map', [
@@ -9261,12 +9261,12 @@ begin
             {44} wbFloat('X'),
             {48} wbFloat('Y'),
             {52} wbFloat('Z')
-          ]),
+          ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
           wbStruct('Rotation', [
             {56} wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
             {60} wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
             {64} wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-          ])
+          ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3)
         ]),
         {68} wbFormIDCk('Severable - Impact DataSet', [IPDS, NULL]),
         {72} wbFormIDCk('Explodable - Impact DataSet', [IPDS, NULL]),
@@ -9401,7 +9401,7 @@ begin
       wbFloat('Red', cpNormal, True, 255, 0),
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbFloat(BNAM, 'Buoyancy'),
     wbInteger(FNAM, 'Flags', itU32, wbFlags([
       'Stair Material',
@@ -10529,7 +10529,7 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Normal Dampener'),
         wbFloatColors('Single Pass Color'),
         wbInteger('Flags', itU32, wbFlags(['Single Pass'])),
@@ -10548,7 +10548,7 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Normal Dampener'),
         wbFloatColors('Single Pass Color'),
         wbInteger('Flags', itU32, wbFlags(['Single Pass']))
@@ -10692,7 +10692,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbInteger('Unused', itU8)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbInteger(GNAM, 'Flags', itU32, wbFlags([
       {0x00000001} 'Trigger Volume',
       {0x00000002} 'Sensor',
@@ -10989,7 +10989,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
       wbStruct(VHGT, 'Vertext Height Map', [
         wbFloat('Offset'),
@@ -11003,7 +11003,7 @@ begin
           wbInteger('X', itU8),
           wbInteger('Y', itU8),
           wbInteger('Z', itU8)
-        ]), 33)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -11102,7 +11102,7 @@ begin
       wbInteger('X', itS16),
       wbInteger('Y', itS16),
       wbInteger('Z', itS16)
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbStruct(ONAM, 'Rotation Offset Constraints', [
       wbInteger('Min', itS16),
       wbInteger('Max', itS16)
@@ -11111,7 +11111,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbString(MOD2, 'Camera Path', 0, cpNormal, False)
   ]);
 
@@ -11614,7 +11614,7 @@ begin
       wbFloat('Red', cpNormal, True, 255, 0),
       wbFloat('Green', cpNormal, True, 255, 0),
       wbFloat('Blue', cpNormal, True, 255, 0)
-    ]),
+    ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     wbStruct(NAM9, 'Face morph', [
       wbFloat('Nose Long/Short'),
       wbFloat('Nose Up/Down'),
@@ -11650,7 +11650,7 @@ begin
           wbInteger('Green', itU8),
           wbInteger('Blue', itU8),
           wbInteger('Alpha', itU8)
-        ]),
+        ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
         wbInteger(TINV, 'Interpolation Value', itU32, wbDiv(100)),
         wbInteger(TIAS, 'Preset', itS16)
       ], []))
@@ -12790,7 +12790,7 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ]),
+    ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
 
     {--- Primitive ---}
     wbStruct(XPRM, 'Primitive', [
@@ -12798,12 +12798,12 @@ begin
         wbFloat('X', cpNormal, True, 2, 4),
         wbFloat('Y', cpNormal, True, 2, 4),
         wbFloat('Z', cpNormal, True, 2, 4)
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Color', [
         {84} wbFloat('Red', cpNormal, False, 255, 0),
         {88} wbFloat('Green', cpNormal, False, 255, 0),
         {92} wbFloat('Blue', cpNormal, False, 255, 0)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbFloat('Unknown'),
       wbInteger('Type', itU32, wbEnum([
         'None',
@@ -12823,7 +12823,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -12845,7 +12845,7 @@ begin
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z')
-      ]),
+      ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
       wbStruct('Rotation (Quaternion?)', [
         wbFloat('q1'),
         wbFloat('q2'),
@@ -13063,7 +13063,7 @@ begin
       wbInteger('Green', itU8),
       wbInteger('Blue', itU8),
       wbByteArray('Unknown', 1)
-    ], cpNormal, True),
+    ], cpNormal, True).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
     {>>> Skyrim.esm has some incorrect FormIDs here, probably leftover <<<}
     wbFormIDCkNoReach(WNAM, 'Worldspace', [WRLD]),
     wbRArray('Region Areas', wbRStruct('Region Area', [
@@ -13152,7 +13152,7 @@ begin
           wbInteger('X', itU16),
           wbInteger('Y', itU16),
           wbInteger('Z', itU16)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbByteArray('Unknown', 2),
         wbByteArray('Unknown', 4)
       ]), 0, nil, nil, cpNormal, False, wbREGNObjectsDontShow),
@@ -13584,12 +13584,12 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbStruct(NAM1, 'Angular Velocity', [
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
-    ], cpNormal, False),
+    ], cpNormal, False).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
     wbString(NAM2, 'Noise Layer One - Noise Texture', 0, cpNormal, False),
     wbString(NAM3, 'Noise Layer Two - Noise Texture', 0, cpNormal, False),
     wbString(NAM4, 'Noise Layer Three - Noise Texture', 0, cpNormal, False),
@@ -13936,7 +13936,7 @@ begin
         wbInteger('Red', itU8),
         wbInteger('Green', itU8),
         wbInteger('Blue', itU8)
-      ]),
+      ]).SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseRGBA),
       wbInteger('Visual Effect - Begin', itU8), // scaled 0..1
       wbInteger('Visual Effect - End', itU8), // scaled 0..1
       wbInteger('Wind Direction', itU8), // scaled 0..360
@@ -14058,12 +14058,12 @@ begin
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbStruct('Rotation', [
           wbFloat('X', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Y', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize),
           wbFloat('Z', cpNormal, True, wbRotationFactor, wbRotationScale, nil, RadiansNormalize)
-        ]),
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
         wbFloat('Scale')
       ]), 0, cpNormal, True)
     ], [], cpNormal, True)

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -3096,7 +3096,7 @@ const
 {V} (Index: 110; Name: 'GetCurrentAIPackage'),
 {V} (Index: 111; Name: 'IsWaiting'),
 {V} (Index: 112; Name: 'IsIdlePlaying'),
-{N} (Index: 116; Name: 'IsIntimidatebyPlayer'),
+{N} (Index: 116; Name: 'IsIntimidatedbyPlayer'),
 {N} (Index: 117; Name: 'IsPlayerInRegion'; ParamType1: ptRegion),
 {V} (Index: 118; Name: 'GetActorAggroRadiusViolated'),
 {V} (Index: 122; Name: 'GetCrime'; ParamType1: ptActor; ParamType2: ptCrimeType),
@@ -6373,7 +6373,7 @@ begin
 
   wbActorValueEnum :=
     wbEnum([
-    {00} 'Aggresion',
+    {00} 'Aggression',
     {01} 'Confidence',
     {02} 'Energy',
     {03} 'Morality',
@@ -8372,7 +8372,7 @@ begin
     wbEDID,
     wbOBNDReq,
     wbRStruct('Textures (RGB/A)', [
-      wbString(TX00,'Difuse'),
+      wbString(TX00,'Diffuse'),
       wbString(TX01,'Normal/Gloss'),
       wbString(TX02,'Environment Mask/Subsurface Tint'),
       wbString(TX03,'Glow/Detail Map'),
@@ -9976,7 +9976,7 @@ begin
     Sig2Int('HBLM'), 'Help - Low Magicka',
     Sig2Int('HBLS'), 'Help - Low Stamina',
     Sig2Int('HBHJ'), 'Help - Jail',
-    Sig2Int('HBFT'), 'Help - Teamate Favor',
+    Sig2Int('HBFT'), 'Help - Teammate Favor',
     Sig2Int('HBWC'), 'Help - Weapon Charge',
     Sig2Int('HBFS'), 'Help - Favorites',
     Sig2Int('KHFL'), 'Kinect Help FormList',
@@ -10939,7 +10939,7 @@ begin
       ]), [18]), [
       wbByteArray(DATA, 'Unknown'),
       wbByteArray(VNML, 'Vertex Normals'),
-      wbByteArray(VHGT, 'Vertext Height Map'),
+      wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
 
       wbRArrayS('Layers', wbRUnion('Layer', [
@@ -10991,7 +10991,7 @@ begin
           wbInteger('Z', itU8)
         ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), 33)
       ]), 33),
-      wbStruct(VHGT, 'Vertext Height Map', [
+      wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbArray('Rows', wbStruct('Row', [
           wbArray('Columns', wbInteger('Column', itU8), 33)

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -805,7 +805,7 @@ var
   wbTints: IwbSubRecordArrayDef;
   wbMODT: IwbSubRecordDef;
   wbDMDT: IwbSubRecordDef;
-  wbOwnership: IwbSubRecordStructDef;
+  wbOwnership: IwbRecordMemberDef;
   wbRACE_DATAFlags01: IwbIntegerDef;
   wbPhonemeTargets: IwbSubRecordDef;
   wbNoseMorphFlags: IwbIntegerDef;
@@ -6164,7 +6164,7 @@ begin
   wbOwnership := wbRStruct('Ownership', [
     wbFormIDCkNoReach(XOWN, 'Owner', [FACT, ACHR, NPC_]),
     wbInteger(XRNK, 'Faction rank', itS32)
-  ], [XRGD]);
+  ], [XRGD]).SetToStr(wbFactionToStr).IncludeFlag(dfCollapsed, wbCollapseFactions);
 
   wbXGLB := wbFormIDCk(XGLB, 'Global variable', [GLOB]);
 end;

--- a/wbInit.pas
+++ b/wbInit.pas
@@ -246,6 +246,8 @@ begin
       wbCollapseScriptProperties := Settings.ReadBool('Options', 'CollapseScriptProperties', wbCollapseScriptProperties);
       wbCollapseConditions := Settings.ReadBool('Options', 'CollapseConditions', wbCollapseConditions);
       wbCollapseBenignArray := Settings.ReadBool('Options', 'CollapseBenignArray', wbCollapseBenignArray);
+      wbCollapseRGBA := Settings.ReadBool('Options', 'CollapseRGBA', wbCollapseRGBA);
+      wbCollapseVec3 := Settings.ReadBool('Options', 'CollapseVec3', wbCollapseVec3);
       sl := TStringList.Create;
       try
         Settings.ReadSection('cpoverride', sl);

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -189,6 +189,8 @@ var
   wbCollapseScriptProperties : Boolean  = True;
   wbCollapseConditions     : Boolean  = True;
   wbCollapseBenignArray    : Boolean  = True;
+  wbCollapseRGBA           : Boolean  = True;
+  wbCollapseVec3           : Boolean  = True;
 
   wbGlobalModifedGeneration : UInt64;
 

--- a/wbLOD.pas
+++ b/wbLOD.pas
@@ -1328,7 +1328,7 @@ begin
 
         wbPrepareImageAlpha(atlas, fmtDiffuse, alphaThreshold);
         if not ConvertImage(atlas, fmtDiffuse) then
-          raise Exception.Create('Image convertion error');
+          raise Exception.Create('Image conversion error');
 
         try
           GenerateMipMaps(atlas, 0, mipmap);
@@ -1367,7 +1367,7 @@ begin
 
         wbPrepareImageAlpha(atlas, fmtNormal);
         if not ConvertImage(atlas, fmtNormal) then
-          raise Exception.Create('Image convertion error');
+          raise Exception.Create('Image conversion error');
 
         try
           GenerateMipMaps(atlas, 0, mipmap);
@@ -1407,7 +1407,7 @@ begin
 
           wbPrepareImageAlpha(atlas, fmtSpecular);
           if not ConvertImage(atlas, fmtSpecular) then
-            raise Exception.Create('Image convertion error');
+            raise Exception.Create('Image conversion error');
 
           try
             GenerateMipMaps(atlas, 0, mipmap);
@@ -1708,7 +1708,7 @@ begin
 
       wbPrepareImageAlpha(Atlases[i], fmtDiffuse);
       if not ConvertImage(Atlases[i], fmtDiffuse) then
-        raise Exception.Create('Image convertion error');
+        raise Exception.Create('Image conversion error');
 
       fname := slAtlas[i];
       if SameText(Copy(fname, 1, 9), 'textures\') then
@@ -1727,7 +1727,7 @@ begin
 
       wbPrepareImageAlpha(Atlases_n[i], fmtNormal);
       if not ConvertImage(Atlases_n[i], fmtNormal) then
-        raise Exception.Create('Image convertion error');
+        raise Exception.Create('Image conversion error');
 
       try
         GenerateMipMaps(Atlases_n[i], 0, mipmap);


### PR DESCRIPTION
- refactored wbDefinitionsCommon
- refactored wbRStructs and wbRStructsSK in definitions to allow callbacks on structs
- summary callbacks now check for ctToSummary
- added compact display for collapsed Color types (RGB/A)
- added compact display for collapsed Ownership (FO3, FNV, TES4, TES5)
- added compact display for collapsed Vec3 types (XYZ)
- fixed issue where lack of Form Version in TES4 Record Header caused crash
- fixed issue where Faction Rank not displayed in collapsed Factions summary
- fixed several typos in Options window and element names

