### PR TITLE
Update xSE plugins for new Wrye Bash CTDA format

### DIFF
--- a/xSE/f4se_plugin_xEdit/main.cpp
+++ b/xSE/f4se_plugin_xEdit/main.cpp
@@ -440,21 +440,19 @@ bool xEditCommand()
 
 	// create the list of condition commands for WB
 	i = 0;
-	j = 0;
-	_MESSAGE("conditionFunctionData = ( #--0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("# 0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("condition_function_data = {");
 	for (ObScriptCommand * iter = g_firstObScriptCommand; iter->opcode < (kObScript_NumObScriptCommands + kObScript_ScriptOpBase); ++iter, i++)
 	{
 		if (iter->eval)
 		{
-			_MESSAGE("    (%3d, '%s', %d, %d, %d),", i, iter->longName,
+			_MESSAGE("    %4d: ('%s', %d, %d, %d),", i, iter->longName,
 				CheckParam(iter, 0) ? WBEncode(iter->params[0]) : 0,
 				CheckParam(iter, 1) ? WBEncode(iter->params[1]) : 0,
-				CheckParam(iter, 2) ? WBEncode(iter->params[2]) : 0,
-				j);
-			j++;
+				CheckParam(iter, 2) ? WBEncode(iter->params[2]) : 0);
 		}
 	}
-	_MESSAGE("    )");	// Don't forget to add xSE functions
+	_MESSAGE("}");	// Don't forget to add xSE functions
 
 	_MESSAGE("");
 

--- a/xSE/fose_plugin_xEdit/main.cpp
+++ b/xSE/fose_plugin_xEdit/main.cpp
@@ -277,20 +277,18 @@ bool FOSEPlugin_Load(const FOSEInterface * fose)
 
 	// create the list of condition commands for WB
 	UInt32 i = 0;
-	UInt32 j = 0;
-	_MESSAGE("conditionFunctionData = ( #--0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("# 0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("condition_function_data = {");
 	for (const CommandInfo * CI = SaveCT->Start(); CI < SaveCT->End(); CI++, i++)
 	{
 		if (CI->eval)
 		{
-			_MESSAGE("    (%3d, '%s', %d, %d), # %3d", i, CI->longName,
+			_MESSAGE("    %4d: ('%s', %d, %d),", i, CI->longName,
 				CheckParam(CI, 0) ? WBEncode(CI->params[0]) : 0,
-				CheckParam(CI, 1) ? WBEncode(CI->params[1]) : 0,
-				j);
-			j++;
+				CheckParam(CI, 1) ? WBEncode(CI->params[1]) : 0);
 		}
 	}
-	_MESSAGE("    )");	// Don't forget to add xSE functions
+	_MESSAGE("}");	// Don't forget to add xSE functions
 
 	_MESSAGE("");
 

--- a/xSE/nvse_plugin_xEdit/main.cpp
+++ b/xSE/nvse_plugin_xEdit/main.cpp
@@ -296,21 +296,19 @@ bool DoTheWork()
 
 	// create the list of condition commands for WB
 	UInt32 i = 0;
-	UInt32 j = 0;
-	_MESSAGE("conditionFunctionData = ( #--0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("# 0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("condition_function_data = {");
 	for (const CommandInfo * CI = SaveCT->Start(); CI < SaveCT->End(); CI++)
 	{
 		if (CI->eval)
 		{
-			_MESSAGE("    (%3d, '%s', %d, %d), # %3d", i, CI->longName,
+			_MESSAGE("    %4d: ('%s', %d, %d),", i, CI->longName,
 				CheckParam(CI, 0) ? WBEncode(CI->params[0]) : 0,
-				CheckParam(CI, 1) ? WBEncode(CI->params[1]) : 0,
-				j);
-			j++;
+				CheckParam(CI, 1) ? WBEncode(CI->params[1]) : 0);
 		}
 		i++;
 	}
-	_MESSAGE("    )");	// Don't forget to add xSE functions
+	_MESSAGE("}");	// Don't forget to add xSE functions
 
 	_MESSAGE("");
 

--- a/xSE/skse64_plugin_xEdit/main.cpp
+++ b/xSE/skse64_plugin_xEdit/main.cpp
@@ -180,21 +180,19 @@ bool xEditCommand()
 
 	// create the list of condition commands for WB
 	i = 0;
-	j = 0;
-	_MESSAGE("conditionFunctionData = ( #--0: no param; 1: int param; 2: formid param");
+	_MESSAGE("# 0: no param; 1: int param; 2: formid param; 3: float param");
+	_MESSAGE("condition_function_data = {");
 	for (ObScriptCommand * iter = g_firstObScriptCommand; iter->opcode < (kObScript_NumObScriptCommands + kObScript_ScriptOpBase); ++iter, i++)
 	{
 		if (iter->eval)
 		{
-			_MESSAGE("    (%3d, '%s'%d, %d, %d),", i, iter->longName,
+			_MESSAGE("    %4d: ('%s', %d, %d, %d),", i, iter->longName,
 				CheckParam(iter, 0) ? WBEncode(iter->params[0]) : 0,
 				CheckParam(iter, 1) ? WBEncode(iter->params[1]) : 0,
-				CheckParam(iter, 2) ? WBEncode(iter->params[2]) : 0,
-				j);
-			j++;
+				CheckParam(iter, 2) ? WBEncode(iter->params[2]) : 0);
 		}
 	}
-	_MESSAGE("    )");	// Don't forget to add SKSE64 functions
+	_MESSAGE("}");	// Don't forget to add SKSE64 functions
 
 	_MESSAGE("");
 


### PR DESCRIPTION
We now use a dict instead of a tuple (O(1) vs O(n) lookup) and `conditionFunctionData` was renamed to `condition_function_data` (PEP8). Also did some code style things (e.g. comment on its own line, no spaces before the closing brace).

Note that I removed the 'j' variable - was unused for two of the plugins, and we removed the comments anyway for the other two plugins - and that I changed the formatting to pad to 4 spaces (since the script extenders add custom functions with 4 digits).