### PR TITLE
Converted record header summary callbacks to declarative style

### DIFF
--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -155,8 +155,6 @@ procedure wbFactionRelationToStr(var aValue: string; aBasePtr: Pointer; aEndPtr:
 
 procedure wbItemToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
-procedure wbRecordHeaderToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
-
 procedure wbRGBAToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
 procedure wbObjectPropertyToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
@@ -1620,33 +1618,6 @@ begin
     Exit;
 
   aValue := ItemString;
-end;
-
-procedure wbRecordHeaderToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
-var
-  Container: IwbContainerElementRef;
-  RecordFlags, FormVersion: IwbElement;
-  MainRecord: IwbMainRecord;
-  RecordFlagsValue, DisplayValue: string;
-begin
-  if not wbTrySetContainer(aElement, aType, Container) then
-    Exit;
-
-  MainRecord := Container.ContainingMainRecord;
-  RecordFlags := Container.ElementByName['Record Flags'];
-  FormVersion := Container.ElementByName['Form Version'];
-
-  RecordFlagsValue := RecordFlags.Value;
-
-  DisplayValue := '[' + MainRecord.Signature + ':' + MainRecord.LoadOrderFormID.ToString(True) + ']';
-
-  aValue := DisplayValue;
-
-  if wbGameMode <> gmTES4 then
-    aValue := '[v' + FormVersion.Value + '] ' + aValue;
-
-  if Length(RecordFlagsValue) > 0 then
-    aValue := aValue + ' {' + RecordFlagsValue + '}';
 end;
 
 /// <summary>Fills PropertyType and PropertyValue from array assigned to property</summary>

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -4261,7 +4261,13 @@ begin
     wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([5, 3])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfSummaryNoSortKey)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -4262,11 +4262,11 @@ begin
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
   ])
-  .SetSummaryKey([5, 3])
+  .SetSummaryKey([5, 3, 2])
   .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .SetSummaryDelimiter(' ')
   .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfSummaryNoSortKey)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4055,11 +4055,11 @@ begin
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
   ])
-  .SetSummaryKey([5, 3])
+  .SetSummaryKey([5, 3, 2])
   .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .SetSummaryDelimiter(' ')
   .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfSummaryNoSortKey)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4054,7 +4054,13 @@ begin
     wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([5, 3])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfSummaryNoSortKey)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -6570,7 +6570,13 @@ begin
     {16} wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4),
     {20} wbInteger('Form Version', itU16, nil, cpIgnore),
     {22} wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([5, 3])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfSummaryNoSortKey)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -6571,11 +6571,11 @@ begin
     {20} wbInteger('Form Version', itU16, nil, cpIgnore),
     {22} wbByteArray('Version Control Info 2', 2, cpIgnore)
   ])
-  .SetSummaryKey([5, 3])
+  .SetSummaryKey([5, 3, 2])
   .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .SetSummaryDelimiter(' ')
   .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfSummaryNoSortKey)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -7531,11 +7531,11 @@ begin
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
   ])
-  .SetSummaryKey([5, 3])
+  .SetSummaryKey([5, 3, 2])
   .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .SetSummaryDelimiter(' ')
   .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfSummaryNoSortKey)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -7530,7 +7530,13 @@ begin
     wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4),
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([5, 3])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfSummaryNoSortKey)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -1841,7 +1841,10 @@ begin
     wbRecordFlags,
     wbFormID('FormID', cpFormID),
     wbByteArray('Version Control Info', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([3])
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 20;
 

--- a/wbDefinitionsTES4.pas
+++ b/wbDefinitionsTES4.pas
@@ -1842,7 +1842,8 @@ begin
     wbFormID('FormID', cpFormID),
     wbByteArray('Version Control Info', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4)
   ])
-  .SetSummaryKey([3])
+  .SetSummaryKey([3, 2])
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .IncludeFlag(dfSummaryMembersNoName)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -5107,11 +5107,11 @@ begin
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
   ])
-  .SetSummaryKey([5, 3])
+  .SetSummaryKey([5, 3, 2])
   .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
   .SetSummaryDelimiter(' ')
   .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfSummaryNoSortKey)
   .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -5106,7 +5106,13 @@ begin
     ]),
     wbInteger('Form Version', itU16, nil, cpIgnore),
     wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ]).SetToStr(wbRecordHeaderToStr).IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  ])
+  .SetSummaryKey([5, 3])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfSummaryNoSortKey)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
 
   wbSizeOfMainRecordStruct := 24;
 


### PR DESCRIPTION
- converted record header summary callbacks to declarative style
- removed record header summary callback from common definitions
- TODO (@ElminsterAU): add literal flag to configure preference for record short name instead of "Self"