### PR TITLE
Moved wbMainRecordHeader to wbDefinitionsCommon (TES5, SSE, FO3, FNV, FO4, FO76)

### DIFF
--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -1087,8 +1087,6 @@ end;
 
 function wbRecordHeader(aRecordFlags: IwbIntegerDef): IwbValueDef;
 begin
-  var wbVersionControlInfo1 := wbByteArray('Version Control Info 1', 4, cpIgnore);
-
   Result := wbStruct('Record Header', [
     wbString('Signature', 4, cpCritical),
     wbInteger('Data Size', itU32, nil, cpIgnore),
@@ -1096,10 +1094,10 @@ begin
     wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
     IfThen(wbGameMode in [gmTES5, gmSSE],
       wbUnion('Version Control Info 1', wbFormVersionDecider(44), [
-        wbVersionControlInfo1.SetToStr(wbVCI1ToStrBeforeFO4),
-        wbVersionControlInfo1.SetToStr(wbVCI1ToStrAfterFO4)
+        wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
+        wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4)
       ]),
-      wbVersionControlInfo1.SetToStr(
+      wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(
         IfThen(wbGameMode in [gmFO3, gmFNV], wbVCI1ToStrBeforeFO4, wbVCI1ToStrAfterFO4)
       )
     ),

--- a/wbDefinitionsCommon.pas
+++ b/wbDefinitionsCommon.pas
@@ -213,6 +213,8 @@ function wbScriptObjFormatDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aEl
 
 {>>> Common Definitions <<<}
 
+function wbRecordHeader(aRecordFlags: IwbIntegerDef; aVCIToStrCallback: TwbToStrCallback): IwbValueDef;
+
 function wbClimateTiming(aTimeCallback: TwbIntToStrCallback; aPhaseCallback: TwbIntToStrCallback): IwbRecordMemberDef;
 
 function wbCNAM(aRequired: Boolean = False): IwbRecordMemberDef;
@@ -1075,6 +1077,25 @@ begin
 end;
 
 {>>> Common Definitions <<<}
+
+function wbRecordHeader(aRecordFlags: IwbIntegerDef; aVCIToStrCallback: TwbToStrCallback): IwbValueDef;
+begin
+  Result := wbStruct('Record Header', [
+    {00} wbString('Signature', 4, cpCritical),
+    {04} wbInteger('Data Size', itU32, nil, cpIgnore),
+    {08} aRecordFlags,
+    {12} wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
+    {16} wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(aVCIToStrCallback),
+    {20} wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
+    {22} wbByteArray('Version Control Info 2', 2, cpIgnore)
+  ])
+  .SetSummaryKey([5, 3, 2])
+  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
+  .SetSummaryMemberPrefixSuffix(2, '{', '}')
+  .SetSummaryDelimiter(' ')
+  .IncludeFlag(dfSummaryMembersNoName)
+  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+end;
 
 function wbClimateTiming(aTimeCallback: TwbIntToStrCallback; aPhaseCallback: TwbIntToStrCallback): IwbRecordMemberDef;
 begin

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -4250,7 +4250,7 @@ begin
     {0x80000000}'Unknown 32'
   ]));                (**)
 
-  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrBeforeFO4);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFNV.pas
+++ b/wbDefinitionsFNV.pas
@@ -4250,21 +4250,7 @@ begin
     {0x80000000}'Unknown 32'
   ]));                (**)
 
-  wbMainRecordHeader := wbStruct('Record Header', [
-    wbString('Signature', 4, cpCritical),
-    wbInteger('Data Size', itU32, nil, cpIgnore),
-    wbRecordFlags,
-    wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
-    wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
-    wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
-    wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ])
-  .SetSummaryKey([5, 3, 2])
-  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
-  .SetSummaryMemberPrefixSuffix(2, '{', '}')
-  .SetSummaryDelimiter(' ')
-  .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrBeforeFO4);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4045,7 +4045,7 @@ begin
     {0x80000000}'Unknown 32'
   ]));                (**)
 
-  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrBeforeFO4);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO3.pas
+++ b/wbDefinitionsFO3.pas
@@ -4045,21 +4045,7 @@ begin
     {0x80000000}'Unknown 32'
   ]));                (**)
 
-  wbMainRecordHeader := wbStruct('Record Header', [
-    wbString('Signature', 4, cpCritical),
-    wbInteger('Data Size', itU32, nil, cpIgnore),
-    wbRecordFlags,
-    wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
-    wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
-    wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
-    wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ])
-  .SetSummaryKey([5, 3, 2])
-  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
-  .SetSummaryMemberPrefixSuffix(2, '{', '}')
-  .SetSummaryDelimiter(' ')
-  .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrBeforeFO4);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -6558,21 +6558,7 @@ begin
 
   wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(wbRecordFlagsFlags, wbFlagsList([])));
 
-  wbMainRecordHeader := wbStruct('Record Header', [
-    {00} wbString('Signature', 4, cpCritical),
-    {04} wbInteger('Data Size', itU32, nil, cpIgnore),
-    {08} wbRecordFlags,
-    {12} wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
-    {16} wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4),
-    {20} wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
-    {22} wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ])
-  .SetSummaryKey([5, 3, 2])
-  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
-  .SetSummaryMemberPrefixSuffix(2, '{', '}')
-  .SetSummaryDelimiter(' ')
-  .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrAfterFO4);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO4.pas
+++ b/wbDefinitionsFO4.pas
@@ -6558,7 +6558,7 @@ begin
 
   wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(wbRecordFlagsFlags, wbFlagsList([])));
 
-  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrAfterFO4);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -7516,7 +7516,7 @@ begin
 
   wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(wbRecordFlagsFlags, wbFlagsList([])));
 
-  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrAfterFO4);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsFO76.pas
+++ b/wbDefinitionsFO76.pas
@@ -7516,21 +7516,7 @@ begin
 
   wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(wbRecordFlagsFlags, wbFlagsList([])));
 
-  wbMainRecordHeader := wbStruct('Record Header', [
-    wbString('Signature', 4, cpCritical),
-    wbInteger('Data Size', itU32, nil, cpIgnore),
-    wbRecordFlags,
-    wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
-    wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4),
-    wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
-    wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ])
-  .SetSummaryKey([5, 3, 2])
-  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
-  .SetSummaryMemberPrefixSuffix(2, '{', '}')
-  .SetSummaryDelimiter(' ')
-  .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags, wbVCI1ToStrAfterFO4);
 
   wbSizeOfMainRecordStruct := 24;
 

--- a/wbDefinitionsTES5.pas
+++ b/wbDefinitionsTES5.pas
@@ -5092,24 +5092,7 @@ begin
 
   wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(wbRecordFlagsFlags, wbFlagsList([])));
 
-  wbMainRecordHeader := wbStruct('Record Header', [
-    wbString('Signature', 4, cpCritical),
-    wbInteger('Data Size', itU32, nil, cpIgnore),
-    wbRecordFlags,
-    wbFormID('FormID', cpFormID).IncludeFlag(dfSummarySelfAsShortName),
-    wbUnion('Version Control Info 1', wbFormVersionDecider(44), [
-      wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrBeforeFO4),
-      wbByteArray('Version Control Info 1', 4, cpIgnore).SetToStr(wbVCI1ToStrAfterFO4)
-    ]),
-    wbInteger('Form Version', itU16, nil, cpIgnore).IncludeFlag(dfSummaryShowIgnore),
-    wbByteArray('Version Control Info 2', 2, cpIgnore)
-  ])
-  .SetSummaryKey([5, 3, 2])
-  .SetSummaryMemberPrefixSuffix(5, '[v', ']')
-  .SetSummaryMemberPrefixSuffix(2, '{', '}')
-  .SetSummaryDelimiter(' ')
-  .IncludeFlag(dfSummaryMembersNoName)
-  .IncludeFlag(dfCollapsed, wbCollapseRecordHeader);
+  wbMainRecordHeader := wbRecordHeader(wbRecordFlags);
 
   wbSizeOfMainRecordStruct := 24;
 


### PR DESCRIPTION
Added new function to `wbDefinitionsCommon`:
```delphi
function wbRecordHeader(aRecordFlags: IwbIntegerDef; aVCIToStrCallback: TwbToStrCallback): IwbValueDef;
```
`wbRecordHeader(...)` is now assigned to `wbMainRecordHeader` in the TES5/SSE, FO3, FNV, FO4, and FO76 definitions.

If we have to update record header summaries again, we need only update 3 definitions (common, TES3, and TES4) instead of 7.