### PR TITLE
implemented cut, paste, and more copy operations

### DIFF
--- a/frmViewMain.dfm
+++ b/frmViewMain.dfm
@@ -2615,6 +2615,36 @@ object frmMain: TfrmMain
     object N9: TMenuItem
       Caption = '-'
     end
+    object mniViewClipboard: TMenuItem
+      Caption = 'Clipboard'
+      OnClick = mniViewClipboardClick
+      object mniCopyPathToClipboard: TMenuItem
+        Caption = 'Copy path'
+        OnClick = mniCopyPathToClipboardClick
+      end
+      object mniCopyFullPathToClipboard: TMenuItem
+        Caption = 'Copy full path'
+        OnClick = mniCopyFullPathToClipboardClick
+      end
+      object mniClipboardSeparator: TMenuItem
+        Caption = '-'
+      end
+      object mniCopyNameToClipboard: TMenuItem
+        Caption = 'Copy name'
+        OnClick = mniCopyNameToClipboardClick
+      end
+      object mniCopyDisplayNameToClipboard: TMenuItem
+        Caption = 'Copy display name'
+        OnClick = mniCopyDisplayNameToClipboardClick
+      end
+      object mniCopyShortNameToClipboard: TMenuItem
+        Caption = 'Copy short name'
+        OnClick = mniCopyShortNameToClipboardClick
+      end
+    end
+    object mniViewClipboardSeparator: TMenuItem
+      Caption = '-'
+    end
     object mniViewHideNoConflict: TMenuItem
       Caption = 'Hide no conflict and empty rows'
       OnClick = mniViewHideNoConflictClick

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -609,7 +609,7 @@ type
     procedure mniSpreadsheetRebuildClick(Sender: TObject);
 
     {--- actions ---}
-    function GetFocusedElementSafely(Sender: TObject): IwbElement;
+    function GetFocusedElementSafely: IwbElement;
 
     procedure acBackUpdate(Sender: TObject);
     procedure acBackExecute(Sender: TObject);
@@ -7476,7 +7476,7 @@ procedure TfrmMain.mniViewClipboardClick(Sender: TObject);
 var
   Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
+  Element := GetFocusedElementSafely;
   if not Assigned(Element) then
     Exit;
 
@@ -11440,7 +11440,7 @@ begin
   if wbShrinkButtons then ShrinkButtons else ExpandButtons;
 end;
 
-function TfrmMain.GetFocusedElementSafely(Sender: TObject): IwbElement;
+function TfrmMain.GetFocusedElementSafely: IwbElement;
 begin
   Result := nil;
 
@@ -11469,35 +11469,35 @@ end;
 
 procedure TfrmMain.mniCopyDisplayNameToClipboardClick(Sender: TObject);
 begin
-  var Element := GetFocusedElementSafely(Sender);
+  var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.DisplayName[True];
 end;
 
 procedure TfrmMain.mniCopyFullPathToClipboardClick(Sender: TObject);
 begin
-  var Element := GetFocusedElementSafely(Sender);
+  var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.FullPath;
 end;
 
 procedure TfrmMain.mniCopyNameToClipboardClick(Sender: TObject);
 begin
-  var Element := GetFocusedElementSafely(Sender);
+  var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.Name;
 end;
 
 procedure TfrmMain.mniCopyPathToClipboardClick(Sender: TObject);
 begin
-  var Element := GetFocusedElementSafely(Sender);
+  var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.Path;
 end;
 
 procedure TfrmMain.mniCopyShortNameToClipboardClick(Sender: TObject);
 begin
-  var Element := GetFocusedElementSafely(Sender);
+  var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.ShortName;
 end;
@@ -14421,9 +14421,8 @@ var
   TargetElement : IwbElement;
   NodeLabel     : String;
 begin
-  Element := GetFocusedElementSafely(Sender);
+  Element := GetFocusedElementSafely;
   mniViewClipboard.Visible := Assigned(Element);
-  mniViewClipboardSeparator.Visible := Assigned(Element);
 
   mniViewHideNoConflict.Visible := True;
   mniViewStick.Visible := False;

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -11441,94 +11441,65 @@ begin
 end;
 
 function TfrmMain.GetFocusedElementSafely(Sender: TObject): IwbElement;
-var
-  NodeDatas                   : PViewNodeDatas;
-  Element                     : IwbElement;
-  FocusedColumn               : TColumnIndex;
 begin
-  NodeDatas := vstView.GetNodeData(vstView.FocusedNode);
+  Result := nil;
+
+  var NodeDatas: PViewNodeDatas := vstView.GetNodeData(vstView.FocusedNode);
   if not Assigned(NodeDatas) then
     Exit;
 
-  FocusedColumn := FocusedColumnOverride;
+  var FocusedColumn := FocusedColumnOverride;
   if FocusedColumn < 0 then
     FocusedColumn := vstView.FocusedColumn;
   if Length(ActiveRecords) = 1 then
     FocusedColumn := 1;
 
-  Element := nil;
+  Result := nil;
   if (FocusedColumn > 0) and (Pred(FocusedColumn) <= High(ActiveRecords)) then
-    Element := NodeDatas[Pred(FocusedColumn)].Element;
+    Result := NodeDatas[Pred(FocusedColumn)].Element;
 
-  if not Assigned(Element) then
-    Exit;
-
-  for var i := Low(ActiveRecords) to High(ActiveRecords) do
-  begin
-    Element := NodeDatas[i].Element;
-    if Assigned(Element) then
-      Break;
-  end;
-
-  if not Assigned(Element) then
-    Exit;
-
-  Result := Element;
+  if not Assigned(Result) then
+    for var i := Low(ActiveRecords) to High(ActiveRecords) do
+    begin
+      Result := NodeDatas[i].Element;
+      if Assigned(Result) then
+        Break;
+    end;
 end;
 
 procedure TfrmMain.mniCopyDisplayNameToClipboardClick(Sender: TObject);
-var
-  Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
-  if not Assigned(Element) then
-    Exit;
-
-  Clipboard.AsText := Element.DisplayName[True];
+  var Element := GetFocusedElementSafely(Sender);
+  if Assigned(Element) then
+    Clipboard.AsText := Element.DisplayName[True];
 end;
 
 procedure TfrmMain.mniCopyFullPathToClipboardClick(Sender: TObject);
-var
-  Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
-  if not Assigned(Element) then
-    Exit;
-
-  Clipboard.AsText := Element.FullPath;
+  var Element := GetFocusedElementSafely(Sender);
+  if Assigned(Element) then
+    Clipboard.AsText := Element.FullPath;
 end;
 
 procedure TfrmMain.mniCopyNameToClipboardClick(Sender: TObject);
-var
-  Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
-  if not Assigned(Element) then
-    Exit;
-
-  Clipboard.AsText := Element.Name;
+  var Element := GetFocusedElementSafely(Sender);
+  if Assigned(Element) then
+    Clipboard.AsText := Element.Name;
 end;
 
 procedure TfrmMain.mniCopyPathToClipboardClick(Sender: TObject);
-var
-  Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
-  if not Assigned(Element) then
-    Exit;
-
-  Clipboard.AsText := Element.Path;
+  var Element := GetFocusedElementSafely(Sender);
+  if Assigned(Element) then
+    Clipboard.AsText := Element.Path;
 end;
 
 procedure TfrmMain.mniCopyShortNameToClipboardClick(Sender: TObject);
-var
-  Element                     : IwbElement;
 begin
-  Element := GetFocusedElementSafely(Sender);
-  if not Assigned(Element) then
-    Exit;
-
-  Clipboard.AsText := Element.ShortName;
+  var Element := GetFocusedElementSafely(Sender);
+  if Assigned(Element) then
+    Clipboard.AsText := Element.ShortName;
 end;
 
 procedure TfrmMain.mniMainLocalizationEditorClick(Sender: TObject);


### PR DESCRIPTION
# Common code
- implemented GetFocusedElementSafely function

# Cut, paste, and copy shortcuts
- added Ctrl+X cut operation that copies Element.EditValue to Clipboard.AsText and sets Element.EditValue to empty (only available when Element.IsEditable)
- added Ctrl+V paste operation that sets Element.EditValue from Clipboard.AsText (only available when Element.IsEditable)
- fixed issue where Ctrl+C did not copy summary when Element.EditValue was empty

# Clipboard submenu
- added Clipboard submenu to View context menu
- added "Copy path" to Clipboard submenu
- added "Copy full path" to Clipboard submenu
- added "Copy name" to Clipboard submenu
- added "Copy display name" (implicit suffix) to Clipboard submenu
- added "Copy short name" to Clipboard submenu

# Dynamic behaviors
- set Clipboard submenu to display only when focused node assigned
- set "Copy display name" submenu item to display only when different from name
- set "Copy short name" submenu item to display only when different from name
- show value previews on Clipboard submenu items (except "Copy full path" due to length)

**Note:** The value preview for "Copy path" is not truncated but most paths are short.