### PR TITLE
clipboard additions and fixes

### DIFF
--- a/frmViewMain.dfm
+++ b/frmViewMain.dfm
@@ -2626,8 +2626,16 @@ object frmMain: TfrmMain
         Caption = 'Copy full path'
         OnClick = mniCopyFullPathToClipboardClick
       end
+      object mniCopyPathNameToClipboard: TMenuItem
+        Caption = 'Copy full path (short names)'
+        OnClick = mniCopyPathNameToClipboardClick
+      end
       object mniClipboardSeparator: TMenuItem
         Caption = '-'
+      end
+      object mniCopySignatureToClipboard: TMenuItem
+        Caption = 'Copy signature'
+        OnClick = mniCopySignatureToClipboardClick
       end
       object mniCopyNameToClipboard: TMenuItem
         Caption = 'Copy name'

--- a/frmViewMain.pas
+++ b/frmViewMain.pas
@@ -445,6 +445,8 @@ type
     mniCopyNameToClipboard: TMenuItem;
     mniCopyDisplayNameToClipboard: TMenuItem;
     mniCopyShortNameToClipboard: TMenuItem;
+    mniCopySignatureToClipboard: TMenuItem;
+    mniCopyPathNameToClipboard: TMenuItem;
 
     {--- Form ---}
     procedure FormClose(Sender: TObject; var Action: TCloseAction);
@@ -722,6 +724,8 @@ type
     procedure mniCopyNameToClipboardClick(Sender: TObject);
     procedure mniCopyDisplayNameToClipboardClick(Sender: TObject);
     procedure mniCopyShortNameToClipboardClick(Sender: TObject);
+    procedure mniCopySignatureToClipboardClick(Sender: TObject);
+    procedure mniCopyPathNameToClipboardClick(Sender: TObject);
 
   protected
     function IsViewNodeFiltered(aNode: PVirtualNode): Boolean;
@@ -7480,11 +7484,23 @@ begin
   if not Assigned(Element) then
     Exit;
 
+  var SubRecord: IwbSubRecord := nil;
+
+  mniCopySignatureToClipboard.Visible := Supports(Element, IwbSubRecord, SubRecord);
   mniCopyDisplayNameToClipboard.Visible := not (Element.DisplayName[True] = Element.Name);
   mniCopyShortNameToClipboard.Visible := not (Element.ShortName = Element.Name);
 
   if not (Element.Path = '') then
-    mniCopyPathToClipboard.Caption := 'Copy path <' + Element.Path + '>';
+    mniCopyPathToClipboard.Caption := 'Copy path <' + ShortenText(Element.Path) + '>';
+
+  if not (Element.PathName = '') then
+    mniCopyPathNameToClipboard.Caption := 'Copy full path (short names) <' + ShortenText(Element.PathName) + '>';
+
+  if not (Element.FullPath = '') then
+    mniCopyFullPathToClipboard.Caption := 'Copy full path <' + ShortenText(Element.FullPath) + '>';
+
+  if mniCopySignatureToClipboard.Visible then
+    mniCopySignatureToClipboard.Caption := 'Copy signature <' + string(SubRecord.Signature) + '>';
 
   if not (Element.Name = '') then
     mniCopyNameToClipboard.Caption := 'Copy name <' + Element.Name + '>';
@@ -11488,6 +11504,13 @@ begin
     Clipboard.AsText := Element.Name;
 end;
 
+procedure TfrmMain.mniCopyPathNameToClipboardClick(Sender: TObject);
+begin
+  var Element := GetFocusedElementSafely;
+  if Assigned(Element) then
+    Clipboard.AsText := Element.PathName;
+end;
+
 procedure TfrmMain.mniCopyPathToClipboardClick(Sender: TObject);
 begin
   var Element := GetFocusedElementSafely;
@@ -11500,6 +11523,17 @@ begin
   var Element := GetFocusedElementSafely;
   if Assigned(Element) then
     Clipboard.AsText := Element.ShortName;
+end;
+
+procedure TfrmMain.mniCopySignatureToClipboardClick(Sender: TObject);
+begin
+  var Element := GetFocusedElementSafely;
+  if not Assigned(Element) then
+    Exit;
+
+  var SubRecord: IwbSubRecord := nil;
+  if Supports(Element, IwbSubRecord, SubRecord) then
+    Clipboard.AsText := string(SubRecord.Signature);
 end;
 
 procedure TfrmMain.mniMainLocalizationEditorClick(Sender: TObject);

--- a/wbImplementation.pas
+++ b/wbImplementation.pas
@@ -16427,7 +16427,7 @@ begin
     Result := IwbElement(eContainer).PathName
   else
     Result := '';
-  Result := Result + '\';
+  Result := Result + ' \ ';
   if Assigned(eContainer) then
     Result := Result + '['+IntToStr(IwbContainer(eContainer).IndexOf(Self))+'] ';
   Result := Result + GetShortName;

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -4279,7 +4279,7 @@ procedure wbVCI1ToStrAfterFO4(var aValue:string; aBasePtr: Pointer; aEndPtr: Poi
 procedure wbTimeStampToString(var aValue:string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 
 /// <summary>Collapse and truncate the given text to fit in the given width.</summary>
-function ShortenText(const aText: string; const aWidth: Integer = 64; const aPlaceholder: string = '...'): string;
+function ShortenText(const aText: string; const aWidth: Integer = 64; const aPlaceholder: string = '…'): string;
 
 implementation
 
@@ -19712,7 +19712,7 @@ begin
   end;
 end;
 
-function ShortenText(const aText: string; const aWidth: Integer = 64; const aPlaceholder: string = '...'): string;
+function ShortenText(const aText: string; const aWidth: Integer; const aPlaceholder: string): string;
 begin
   // collapse whitespace (all whitespace is replaced by single spaces)
   Result := TRegEx.Replace(aText, '\t\n\v\f\r', ' ');

--- a/wbInterface.pas
+++ b/wbInterface.pas
@@ -23,7 +23,8 @@ uses
   Classes,
   SysUtils,
   UITypes,
-  Graphics;
+  Graphics,
+  RegularExpressions;
 
 type
   TwbVersion = record
@@ -4276,6 +4277,9 @@ function wbMBCSEncoding(s: string): TEncoding; overload;
 procedure wbVCI1ToStrBeforeFO4(var aValue:string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 procedure wbVCI1ToStrAfterFO4(var aValue:string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
 procedure wbTimeStampToString(var aValue:string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
+
+/// <summary>Collapse and truncate the given text to fit in the given width.</summary>
+function ShortenText(const aText: string; const aWidth: Integer = 64; const aPlaceholder: string = '...'): string;
 
 implementation
 
@@ -16140,13 +16144,8 @@ begin
   Result := '';
   if Assigned(ndToStr) then
     ndToStr(Result, aBasePtr, aEndPtr, aElement, ctToSummary);
-  if Result = '' then begin
-    Result := ToString(aBasePtr, aEndPtr, aElement);
-    if Length(Result) > 64 then begin
-      SetLength(Result, 61);
-      Result := Result + '...';
-    end;
-  end;
+  if Result = '' then
+    Result := ShortenText(ToString(aBasePtr, aEndPtr, aElement));
 end;
 
 { TwbSubRecordStructSKDef }
@@ -19710,6 +19709,18 @@ begin
       aValue := Format('%.4d-%.2d-%.2d', [Year, Month, Day]);
     end else
       aValue := 'None';
+  end;
+end;
+
+function ShortenText(const aText: string; const aWidth: Integer = 64; const aPlaceholder: string = '...'): string;
+begin
+  // collapse whitespace (all whitespace is replaced by single spaces)
+  Result := TRegEx.Replace(aText, '\t\n\v\f\r', ' ');
+
+  if Length(Result) > aWidth then
+  begin
+    SetLength(Result, aWidth - Length(aPlaceholder));
+    Result := Result + aPlaceholder;
   end;
 end;
 


### PR DESCRIPTION
# Common code
- added ShortenText function (collapses and truncates text to fit width)
- replaced similar code in TwbValueDef.ToSummary with that new function

**Note:** The ShortenText function uses TRegEx to collapse whitespace (`\t\n\v\f\r`) to single spaces to avoid strange output issues. Partially modeled after Python's [textwrap.shorten](https://docs.python.org/3.7/library/textwrap.html#textwrap.shorten) method. Collapsing whitespace is possibly unnecessary with respect to the current slate of clipboard previews and TwbValueDef summaries, but we may want to use this function elsewhere where that would be useful.

# Clipboard submenu
## New items
- added "Copy signature" to Clipboard submenu
- added "Copy full path (short names)" to Clipboard submenu

## Dynamic behaviors
- set "Copy signature" submenu item to display only for IwbSubRecordDef elements
- show value previews for all Clipboard submenu items
- fixed issue where long value previews were not truncated on Clipboard submenu

# Miscellaneous fixes
- fixed issue where TwbElement.GetPathName separator was not enclosed with spaces
