### PR TITLE
added TwbElement.GetIndexedPath and IndexedPath script function

### DIFF
--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -336,6 +336,7 @@ type
     function GetDisplayName(aUseSuffix: Boolean): string; virtual;
     function GetShortName: string; virtual;
     function GetPath: string; virtual;
+    function GetIndexedPath: string; virtual;
     function GetFullPath: string; virtual;
     function GetPathName: string; virtual;
     function GetSkipped: Boolean; virtual;
@@ -16446,6 +16447,18 @@ end;
 function TwbElement.GetFound: Boolean;
 begin
   Result := esFound in eStates;
+end;
+
+function TwbElement.GetIndexedPath: string;
+begin
+  if Assigned(eContainer) then
+    Result := IwbElement(eContainer).IndexedPath
+  else
+    Result := '';
+  if Length(Result) > 0 then
+    Result := Result + '\';
+  if Assigned(eContainer) then
+    Result := Result + '['+IntToStr(IwbContainer(eContainer).IndexOf(Self))+']';
 end;
 
 function TwbElement.GetFullPath: string;

--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -336,7 +336,7 @@ type
     function GetDisplayName(aUseSuffix: Boolean): string; virtual;
     function GetShortName: string; virtual;
     function GetPath: string; virtual;
-    function GetIndexedPath: string; virtual;
+    function GetIndexedPath(aIndexFromFile: Boolean = True): string; virtual;
     function GetFullPath: string; virtual;
     function GetPathName: string; virtual;
     function GetSkipped: Boolean; virtual;
@@ -16449,12 +16449,16 @@ begin
   Result := esFound in eStates;
 end;
 
-function TwbElement.GetIndexedPath: string;
+function TwbElement.GetIndexedPath(aIndexFromFile: Boolean = True): string;
 begin
   if Assigned(eContainer) then
-    Result := IwbElement(eContainer).IndexedPath
+    Result := IwbElement(eContainer).IndexedPath[aIndexFromFile]
   else
     Result := '';
+
+  if not aIndexFromFile and Assigned(eContainer) and (IwbElement(eContainer).ElementType in [etFile, etGroupRecord]) then
+    Exit;
+
   if Length(Result) > 0 then
     Result := Result + '\';
   if Assigned(eContainer) then

--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -885,7 +885,7 @@ type
     function GetDisplayName(aUseSuffix: Boolean): string;
     function GetShortName: string;
     function GetPath: string;
-    function GetIndexedPath: string;
+    function GetIndexedPath(aIndexFromFile: Boolean = True): string;
     function GetFullPath: string;
     function GetPathName: string;
     function GetSkipped: Boolean;
@@ -1025,7 +1025,7 @@ type
       read GetShortName;
     property Path: string
       read GetPath;
-    property IndexedPath: string
+    property IndexedPath[aIndexFromFile: Boolean]: string
       read GetIndexedPath;
     property FullPath: string
       read GetFullPath;

--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -885,6 +885,7 @@ type
     function GetDisplayName(aUseSuffix: Boolean): string;
     function GetShortName: string;
     function GetPath: string;
+    function GetIndexedPath: string;
     function GetFullPath: string;
     function GetPathName: string;
     function GetSkipped: Boolean;
@@ -1024,6 +1025,8 @@ type
       read GetShortName;
     property Path: string
       read GetPath;
+    property IndexedPath: string
+      read GetIndexedPath;
     property FullPath: string
       read GetFullPath;
     property PathName: string

--- a/xEdit/JvI/xejviScriptAdapter.pas
+++ b/xEdit/JvI/xejviScriptAdapter.pas
@@ -340,7 +340,7 @@ var
 begin
   Value := '';
   if Supports(IInterface(Args.Values[0]), IwbElement, Element) then
-    Value := Element.IndexedPath;
+    Value := Element.IndexedPath[Boolean(Args.Values[1])];
 end;
 
 procedure IwbElement_FullPath(var Value: Variant; Args: TJvInterpreterArgs);
@@ -1943,7 +1943,7 @@ begin
     AddFunction(cUnit, 'BaseName', IwbElement_BaseName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'DisplayName', IwbElement_DisplayName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'Path', IwbElement_Path, 1, [varEmpty], varEmpty);
-    AddFunction(cUnit, 'IndexedPath', IwbElement_IndexedPath, 1, [varEmpty], varEmpty);
+    AddFunction(cUnit, 'IndexedPath', IwbElement_IndexedPath, 2, [varEmpty, varBoolean], varEmpty);
     AddFunction(cUnit, 'FullPath', IwbElement_FullPath, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'PathName', IwbElement_PathName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'ElementType', IwbElement_ElementType, 1, [varEmpty], varEmpty);

--- a/xEdit/JvI/xejviScriptAdapter.pas
+++ b/xEdit/JvI/xejviScriptAdapter.pas
@@ -334,6 +334,15 @@ begin
     Value := Element.Path;
 end;
 
+procedure IwbElement_IndexedPath(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  Element: IwbElement;
+begin
+  Value := '';
+  if Supports(IInterface(Args.Values[0]), IwbElement, Element) then
+    Value := Element.IndexedPath;
+end;
+
 procedure IwbElement_FullPath(var Value: Variant; Args: TJvInterpreterArgs);
 var
   Element: IwbElement;
@@ -1934,6 +1943,7 @@ begin
     AddFunction(cUnit, 'BaseName', IwbElement_BaseName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'DisplayName', IwbElement_DisplayName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'Path', IwbElement_Path, 1, [varEmpty], varEmpty);
+    AddFunction(cUnit, 'IndexedPath', IwbElement_IndexedPath, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'FullPath', IwbElement_FullPath, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'PathName', IwbElement_PathName, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'ElementType', IwbElement_ElementType, 1, [varEmpty], varEmpty);


### PR DESCRIPTION
`IndexedPath(e: IInterface; aIndexFromFile: Boolean)` returns a file-relative or record-relative full path to the element comprised entirely of indices. This string can be passed directly to `ElementByPath`.

# Usage
## Indexed Path, relative to file
```delphi
sIndexFromFile := IndexedPath(ElementByPath(e, 'EDID'), True);  // result: [4]\[68]\[1]
kElement := ElementByPath(e, sIndexFromFile);  // result: =  \ [00] Skyrim.esm \ [4] GRUP Top "AACT" \ [68] ActionIdle [AACT:00013002] \ [1] EDID - Editor ID
```

## Indexed Path, relative to record
```delphi
sIndexFromRecord := IndexedPath(ElementByPath(e, 'EDID'), False);  // result: [1]
kElement := ElementByPath(e, sIndexFromRecord);  // result: =  \ [00] Skyrim.esm \ [4] GRUP Top "AACT" \ [68] ActionIdle [AACT:00013002] \ [1] EDID - Editor ID
```

# Example Script
This example script creates a TStringList of key-value pairs (indexed path, edit value) from a Destructible element that can be reused wherever needed.

```delphi
unit UserScript;

var
  bIndexFromFile: Boolean;
  slPathValuePairs: TStringList;

function Initialize: Integer;
begin
  bIndexFromFile := True;
  slPathValuePairs := TStringList.Create;
end;

function Process(e: IInterface): Integer;
begin
  BuildPathValuePairs(ElementByPath(e, 'Destructible'), slPathValuePairs);
end;

function Finalize: Integer;
begin
  AddMessage(slPathValuePairs.Text);
  slPathValuePairs.Free;
end;

procedure BuildPathValuePairs(e: IInterface; slPaths: TStringList);
var
  sValue    : String;
  i         : Integer;
begin
  sValue := GetEditValue(e);
  if Length(sValue) > 0 then
    slPaths.Append(IndexedPath(e, bIndexFromFile) + '=' + sValue);

  for i := 0 to Pred(ElementCount(e)) do
    BuildPathValuePairs(ElementByIndex(e, i), slPaths);
end;

end.
```

If `bIndexFromFile` is set to `True` (file-relative indexed paths), then you could generate the following results:

```
[1]\[3]\[5]\[0]\[0]=1
[1]\[3]\[5]\[0]\[1]=1
[1]\[3]\[5]\[0]\[2]=False
[1]\[3]\[5]\[0]\[3]=00 00
[1]\[3]\[5]\[1]\[0]\[0]\[0]=0
[1]\[3]\[5]\[1]\[0]\[0]\[1]=0
[1]\[3]\[5]\[1]\[0]\[0]\[2]=0
[1]\[3]\[5]\[1]\[0]\[0]\[3]=001
[1]\[3]\[5]\[1]\[0]\[0]\[3]\[0]=1
[1]\[3]\[5]\[1]\[0]\[0]\[4]=0
[1]\[3]\[5]\[1]\[0]\[0]\[5]=PotBreakExp [EXPL:0700288F]
[1]\[3]\[5]\[1]\[0]\[0]\[6]=NULL - Null Reference [00000000]
[1]\[3]\[5]\[1]\[0]\[0]\[7]=0
[1]\[3]\[5]\[1]\[0]\[1]\[0]=Destructible Skyrim\RuinsPot03_Broken.nif
```

The first index (`[1]`) the index of the top-level group in the file. The second index (`[3]`) is the index of the record in the group.

If we know we will not be adding or removing groups and records, we can access this data simply:

```delphi
// slPathValuePairs: TStringList was created using the above script.
for i := 0 to Pred(slPathValuePairs.Count) do
begin
  // notice that we pass an IwbFile as the first argument because the path is a file-relative indexed path
  SetElementEditValues(GetFile(SomeMainRecord), slPathValuePairs.Names[i], slPathValuePairs.Values[slPathValuePairs.Names[i]]);
end;
```

Since these indices are likely to change when groups and records are added and removed, we may want to pass `False` to `IndexedPath`, which toggles off file-relative indexed paths.

If `bIndexFromFile` is set to `False` (record-relative indexed paths), then you could generate the following results:

```
[5]\[0]\[0]=1
[5]\[0]\[1]=1
[5]\[0]\[2]=False
[5]\[0]\[3]=00 00
[5]\[1]\[0]\[0]\[0]=0
[5]\[1]\[0]\[0]\[1]=0
[5]\[1]\[0]\[0]\[2]=0
[5]\[1]\[0]\[0]\[3]=001
[5]\[1]\[0]\[0]\[3]\[0]=1
[5]\[1]\[0]\[0]\[4]=0
[5]\[1]\[0]\[0]\[5]=PotBreakExp [EXPL:0700288F]
[5]\[1]\[0]\[0]\[6]=NULL - Null Reference [00000000]
[5]\[1]\[0]\[0]\[7]=0
[5]\[1]\[0]\[1]\[0]=Destructible Skyrim\RuinsPot03_Broken.nif
```

As you can see, the initial `[1]` and  `[3]` indices are not present. We start at `[5]` which is the index of the `Destructible` element in the record.

## Example Solution

**Problem:** We want to copy a Destructible element from a MISC record to an ACTI record. We can't do that with `wbCopyElementToRecord` because between records of different signatures the sort order of elements may not match, and that function was not designed for copying elements across record types.

**Approach:** First, we need to map these indexed paths from a MISC Destructible element to an ACTI Destructible element.  In an ACTI record, the index (sort order) of the Destructible element is 6, not 5, so we want to change the initial `[5]` in our list of key-value pairs to `[6]`. We should then perform all the necessary `ElementAssign` or `Add` operations to make sure the indexed paths are valid for the target record. Finally, we can iterate over the modified list and set the edit values for each path.

**Solution:** The first and final parts of that approach might look something like:

```delphi
// slPathValuePairs: TStringList was created using the above script.
for i := 0 to Pred(slPathValuePairs.Count) do
begin
  sTargetPath := StringReplace(slPathValuePairs.Names[i], '[5]', '[6]', nil);  // replaces the first occurrence of [5] with [6] and sets sPath to the new adjusted indexed path
  SetElementEditValues(targetRecord, sTargetPath, slPathValuePairs.Values[slPathValuePairs.Names[i]]);
end;
```

Using regular expressions, we can generalize this further but that is out-of-scope for this PR.