### PR TITLE
#799: fixed issue where Change FormID dialog could be opened with File Header selected

### DIFF
--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -11841,6 +11841,9 @@ var
   Master     : IwbMainRecord;
   FileFormID : TwbFormID;
 begin
+  if GetSignature = 'TES4' then
+    aFormID := TwbFormID.Null;
+
   if GetLoadOrderFormID = aFormID then
     Exit;
 

--- a/xEdit/xeMainForm.pas
+++ b/xEdit/xeMainForm.pas
@@ -14063,6 +14063,7 @@ begin
     wbEditAllowed and
     Assigned(Element) and
     (Element.ElementType = etMainRecord) and
+    ((Element as IwbMainRecord).Signature <> 'TES4') and
     Element.IsEditable;
 //  if mniNavChangeFormID.Visible then
 //    with Element as IwbMainRecord do


### PR DESCRIPTION
- fixed issue where Change FormID dialog could be opened with File Header selected
- fixed issue where TwbMainRecord.SetLoadOrderFormID could be called on File Header