### PR TITLE
Added expert option to allow integer Form IDs in search and Form ID editor

### DIFF
--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -176,6 +176,7 @@ var
   wbAlwaysSaveOnamForce    : Boolean  = False;
   wbManualCleaningAllow    : Boolean  = False;
   wbManualCleaningHide     : Boolean  = False;
+  wbConvertIntFormID       : Boolean  = False;
   wbShrinkButtons          : Boolean  = False;
   wbCollapseRecordHeader   : Boolean  = True;
   wbCollapseObjectBounds   : Boolean  = True;

--- a/xEdit/xeMainForm.pas
+++ b/xEdit/xeMainForm.pas
@@ -5235,6 +5235,7 @@ begin
   wbAlignArrayElements := Settings.ReadBool('Options', 'AlignArrayElements', wbAlignArrayElements);
   wbManualCleaningHide := Settings.ReadBool('Options', 'ManualCleaningHide', wbManualCleaningHide);
   wbManualCleaningAllow := Settings.ReadBool('Options', 'ManualCleaningAllow', wbManualCleaningAllow);
+  wbConvertIntFormID := Settings.ReadBool('Options', 'ConvertIntFormID', wbConvertIntFormID);
   wbCollapseRecordHeader := Settings.ReadBool('Options', 'CollapseRecordHeader', wbCollapseRecordHeader);
   wbCollapseObjectBounds := Settings.ReadBool('Options', 'CollapseObjectBounds', wbCollapseObjectBounds);
   wbCollapseModels := Settings.ReadBool('Options', 'CollapseModels', wbCollapseModels);
@@ -5447,13 +5448,26 @@ var
   _File                       : IwbFile;
   MainRecord                  : IwbMainRecord;
   Node                        : PVirtualNode;
-  i, j                        : Integer;
+  i, j, tmp                   : Integer;
 
 begin
   if (Key = VK_RETURN) and (Shift = []) then begin
     Key := 0;
 
     s := Trim(edFormIDSearch.Text);
+
+    if wbConvertIntFormID then
+      if not StartsText('0', s) and not StartsText('0x', s) then
+        if TryStrToInt(s, tmp) then
+        begin
+          s := IntToHex(tmp, 8);
+          edFormIDSearch.Text := s;
+        end else
+          s := '00000000';
+
+    if StartsText('0x', s) then
+      s := ReplaceText(s, '0x', '');
+
     FormID := TwbFormID.FromStrDef(s, 0);
     FileID := FormID.FileID;
     if not FormID.IsNull then begin
@@ -9402,6 +9416,17 @@ begin
       // string editor
       else if not InputQuery('Edit Value', 'Please change the value:', EditValue) then
         Exit;
+
+      if wbConvertIntFormID and Element.CanContainFormIDs then
+      begin
+        var tmp: Integer;
+        if not StartsText('0', EditValue) and not StartsText('0x', EditValue) then
+          if TryStrToInt(EditValue, tmp) then
+            EditValue := IntToHex(tmp, 8);
+
+        if StartsText('0x', EditValue) then
+          EditValue := ReplaceText(EditValue, '0x', '');
+      end;
 
       Element.EditValue := EditValue;
       ActiveRecords[Pred(vstView.FocusedColumn)].UpdateRefs;
@@ -13360,6 +13385,7 @@ begin
     cbAlignArrayElements.Checked := wbAlignArrayElements;
     cbManualCleaningHide.Checked := wbManualCleaningHide;
     cbManualCleaningAllow.Checked := wbManualCleaningAllow;
+    cbConvertIntFormID.Checked := wbConvertIntFormID;
     cbCollapseRecordHeader.Checked := wbCollapseRecordHeader;
     cbCollapseObjectBounds.Checked := wbCollapseObjectBounds;
     cbCollapseModels.Checked := wbCollapseModels;
@@ -13431,6 +13457,7 @@ begin
     wbAlignArrayElements := cbAlignArrayElements.Checked;
     wbManualCleaningHide := cbManualCleaningHide.Checked;
     wbManualCleaningAllow := cbManualCleaningAllow.Checked;
+    wbConvertIntFormID := cbConvertIntFormID.Checked;
     wbCollapseRecordHeader := cbCollapseRecordHeader.Checked;
     wbCollapseObjectBounds := cbCollapseObjectBounds.Checked;
     wbCollapseModels := cbCollapseModels.Checked;
@@ -13501,6 +13528,7 @@ begin
     Settings.WriteBool('Options', 'AlignArrayElements', wbAlignArrayElements);
     Settings.WriteBool('Options', 'ManualCleaningHide', wbManualCleaningHide);
     Settings.WriteBool('Options', 'ManualCleaningAllow', wbManualCleaningAllow);
+    Settings.WriteBool('Options', 'ConvertIntFormID', wbConvertIntFormID);
     Settings.WriteBool('Options', 'CollapseRecordHeader', wbCollapseRecordHeader);
     Settings.WriteBool('Options', 'CollapseObjectBounds', wbCollapseObjectBounds);
     Settings.WriteBool('Options', 'CollapseModels', wbCollapseModels);

--- a/xEdit/xeOptionsForm.dfm
+++ b/xEdit/xeOptionsForm.dfm
@@ -780,6 +780,16 @@ object frmOptions: TfrmOptions
         Caption = 'Decode Texture Hashes (requires restart)'
         TabOrder = 7
       end
+      object cbConvertIntFormID: TCheckBox
+        Left = 16
+        Top = 194
+        Width = 438
+        Height = 24
+        Caption = 
+          'Allow use of integer FormIDs (requires '#39'0x'#39' prefix on hex FormID' +
+          's)'
+        TabOrder = 8
+      end
     end
   end
   object btnOK: TButton

--- a/xEdit/xeOptionsForm.pas
+++ b/xEdit/xeOptionsForm.pas
@@ -110,6 +110,7 @@ type
     cbCollapseRGBA: TCheckBox;
     cbCollapseVec3: TCheckBox;
     cbDecodeTexture: TCheckBox;
+    cbConvertIntFormID: TCheckBox;
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormCreate(Sender: TObject);
     procedure cbConflictThisChange(Sender: TObject);


### PR DESCRIPTION
Added expert option to allow integer Form IDs in search and Form ID editor

When this option is enabled (default: off), you can use the integer representation of Form IDs in:

- the Form ID search box, and
- when editing Form ID elements.

The integer is converted to hexadecimal and passed along from there. In the Form ID search box, the box will also update to show the conversion result.

This option (soft) requires that hexadecimal addresses are prefixed with `0x`. This is to avoid unintended conversions. For example:

- `0x14` refers to `00000014`, but 
- `14` is converted to `0000000E`.

The user can also use a `0` prefix instead of `0x` because a `0`-prefixed string is not an integer and therefore will not be converted. That Form IDs with leading zeroes are hexadecimal addresses is probably a good assumption.

The main reason for this option is that hex Form IDs are stored in compiled scripts as integers, so when they're decompiled, you get Form IDs as integers. In addition, Papyrus accepts Form IDs as both integers and hex. Automatically converting those Form IDs in xEdit is more convenient than the usual procedure.