### PR TITLE
extended TStringList with set operations

### DIFF
--- a/xEdit/JvI/xejviScriptAdapterMisc.pas
+++ b/xEdit/JvI/xejviScriptAdapterMisc.pas
@@ -363,6 +363,80 @@ end;
 
 { TStringList }
 
+procedure StringSetOp_Difference(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+begin
+  for var i := 0 to Pred(aSetListA.Count) do
+    if aSetListB.IndexOf(aSetListA[i]) = -1 then
+      aLH.Append(aSetListA[i]);
+end;
+
+procedure StringSetOp_Intersection(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+begin
+  for var i := 0 to Pred(aSetListA.Count) do
+    if aSetListB.IndexOf(aSetListA[i]) > -1 then
+      aLH.Append(aSetListA[i]);
+end;
+
+procedure StringSetOp_SymmetricDifference(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+begin
+  aLH.AddStrings(aSetListA);
+  aLH.AddStrings(aSetListB);
+
+  var Intersection: TStringList := TStringList.Create;
+
+  for var i := 0 to Pred(aSetListA.Count) do
+    if aSetListB.IndexOf(aSetListA[i]) > -1 then
+      Intersection.Append(aSetListA[i]);
+
+  for var i := 0 to Pred(Intersection.Count) do
+  begin
+    var j := aLH.IndexOf(Intersection[i]);
+    if j > -1 then
+      aLH.Delete(j);
+  end;
+
+  Intersection.Free;
+end;
+
+procedure StringSetOp_Union(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+begin
+  aLH.AddStrings(aSetListA);
+  aLH.AddStrings(aSetListB);
+end;
+
+type
+   TSetOperation = (D, I, S, U);
+
+procedure StringSetOp(const aOperation: TSetOperation; const aRH: TStringList; var aLH: TStringList);
+begin
+  { Executes set operations on TStringList objects and modifies aListA in-place }
+
+  aLH.Duplicates := dupIgnore;
+  aLH.Sorted := True;
+
+  var SetListA: TStringList := TStringList.Create;
+  SetListA.Duplicates := dupIgnore;
+  SetListA.Sorted := True;
+  SetListA.AddStrings(aLH);
+
+  var SetListB: TStringList := TStringList.Create;
+  SetListB.Duplicates := dupIgnore;
+  SetListB.Sorted := True;
+  SetListB.AddStrings(aRH);
+
+  aLH.Clear;
+
+  case aOperation of
+    D : StringSetOp_Difference(SetListA, SetListB, aLH);
+    I : StringSetOp_Intersection(SetListA, SetListB, aLH);
+    S : StringSetOp_SymmetricDifference(SetListA, SetListB, aLH);
+    U : StringSetOp_Union(SetListA, SetListB, aLH);
+  end;
+
+  SetListA.Free;
+  SetListB.Free;
+end;
+
 procedure TStringList_Read_CaseSensitive(var Value: Variant; Args: TJvInterpreterArgs);
 begin
   Value := TStringList(Args.Obj).CaseSensitive;
@@ -371,6 +445,26 @@ end;
 procedure TStringList_Write_CaseSensitive(const Value: Variant; Args: TJvInterpreterArgs);
 begin
   TStringList(Args.Obj).CaseSensitive := Value;
+end;
+
+procedure TStringList_Difference(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  StringSetOp(TSetOperation.D, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+end;
+
+procedure TStringList_Intersection(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  StringSetOp(TSetOperation.I, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+end;
+
+procedure TStringList_SymmetricDifference(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  StringSetOp(TSetOperation.S, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+end;
+
+procedure TStringList_Union(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  StringSetOp(TSetOperation.U, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
 end;
 
 
@@ -1903,6 +1997,10 @@ begin
     { TStringList }
     AddGet(TStrings, 'CaseSensitive', TStringList_Read_CaseSensitive, 0, [varEmpty], varEmpty);
     AddSet(TStrings, 'CaseSensitive', TStringList_Write_CaseSensitive, 0, [varEmpty]);
+    AddGet(TStrings, 'Difference', TStringList_Difference, 1, [varEmpty], varEmpty);
+    AddGet(TStrings, 'Intersection', TStringList_Intersection, 1, [varEmpty], varEmpty);
+    AddGet(TStrings, 'SymmetricDifference', TStringList_SymmetricDifference, 1, [varEmpty], varEmpty);
+    AddGet(TStrings, 'Union', TStringList_Union, 1, [varEmpty], varEmpty);
 
     { THashedStringList }
     AddClass('IniFiles', THashedStringList, 'THashedStringList');

--- a/xEdit/JvI/xejviScriptAdapterMisc.pas
+++ b/xEdit/JvI/xejviScriptAdapterMisc.pas
@@ -363,21 +363,21 @@ end;
 
 { TStringList }
 
-procedure StringSetOp_Difference(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+procedure StringSetOp_Difference(const aSetListA: TStringList; const aSetListB: TStringList; const aLH: TStringList);
 begin
   for var i := 0 to Pred(aSetListA.Count) do
     if aSetListB.IndexOf(aSetListA[i]) = -1 then
       aLH.Append(aSetListA[i]);
 end;
 
-procedure StringSetOp_Intersection(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+procedure StringSetOp_Intersection(const aSetListA: TStringList; const aSetListB: TStringList; const aLH: TStringList);
 begin
   for var i := 0 to Pred(aSetListA.Count) do
     if aSetListB.IndexOf(aSetListA[i]) > -1 then
       aLH.Append(aSetListA[i]);
 end;
 
-procedure StringSetOp_SymmetricDifference(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+procedure StringSetOp_SymmetricDifference(const aSetListA: TStringList; const aSetListB: TStringList; const aLH: TStringList);
 begin
   aLH.AddStrings(aSetListA);
   aLH.AddStrings(aSetListB);
@@ -398,7 +398,7 @@ begin
   Intersection.Free;
 end;
 
-procedure StringSetOp_Union(const aSetListA: TStringList; const aSetListB: TStringList; var aLH: TStringList);
+procedure StringSetOp_Union(const aSetListA: TStringList; const aSetListB: TStringList; const aLH: TStringList);
 begin
   aLH.AddStrings(aSetListA);
   aLH.AddStrings(aSetListB);
@@ -407,7 +407,7 @@ end;
 type
    TSetOperation = (D, I, S, U);
 
-procedure StringSetOp(const aOperation: TSetOperation; const aRH: TStringList; var aLH: TStringList);
+procedure StringSetOp(const aOperation: TSetOperation; const aLH: TStringList; const aRH: TStringList);
 begin
   { Executes set operations on TStringList objects and modifies aListA in-place }
 
@@ -449,22 +449,22 @@ end;
 
 procedure TStringList_Difference(var Value: Variant; Args: TJvInterpreterArgs);
 begin
-  StringSetOp(TSetOperation.D, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+  StringSetOp(TSetOperation.D, TStringList(Args.Obj), TStringList(V2O(Args.Values[0])));
 end;
 
 procedure TStringList_Intersection(var Value: Variant; Args: TJvInterpreterArgs);
 begin
-  StringSetOp(TSetOperation.I, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+  StringSetOp(TSetOperation.I, TStringList(Args.Obj), TStringList(V2O(Args.Values[0])));
 end;
 
 procedure TStringList_SymmetricDifference(var Value: Variant; Args: TJvInterpreterArgs);
 begin
-  StringSetOp(TSetOperation.S, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+  StringSetOp(TSetOperation.S, TStringList(Args.Obj), TStringList(V2O(Args.Values[0])));
 end;
 
 procedure TStringList_Union(var Value: Variant; Args: TJvInterpreterArgs);
 begin
-  StringSetOp(TSetOperation.U, TStringList(V2O(Args.Values[0])), TStringList(Args.Obj));
+  StringSetOp(TSetOperation.U, TStringList(Args.Obj), TStringList(V2O(Args.Values[0])));
 end;
 
 


### PR DESCRIPTION
- added TStringList.Difference script procedure
- added TStringList.Intersection script procedure
- added TStringList.SymmetricDifference script procedure
- added TStringList.Union script procedure

All procedures modify `Self` in-place instead of returning a new TStringList.

The `StringSetOp` and `StringSetOp_*` procedures may need an optimization pass. I used language features to make quick work of these operations, so each procedure may not be O(n).

In practice:

```delphi
k := ElementBySignature(e, 'KWDA');
for i := 0 to Pred(ElementCount(k)) do
  keywords.Append(EditorID(LinksTo(ElementByIndex(k, i))));

keywords.Intersection(excludedKeywords);

if keywords.Count = 0 then
  AddMessage('Element does not have excluded keywords.');
```