### PR TITLE
added clipboard access routines to interpreter (GetClipboardText, SetClipboardText)

### DIFF
--- a/xEdit/JvI/xejviScriptAdapterMisc.pas
+++ b/xEdit/JvI/xejviScriptAdapterMisc.pas
@@ -39,6 +39,7 @@ uses
   IniFiles,
   Registry,
   Math,
+  Vcl.Clipbrd,
   RegularExpressionsCore,
   RegularExpressionsConsts,
   JsonDataObjects,
@@ -67,6 +68,22 @@ begin
       Result := i;
       Break;
     end;
+end;
+
+{ Clipboard }
+
+procedure JvInterpreter_Clipboard_GetAsText(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  Value := Clipboard.AsText;
+end;
+
+procedure JvInterpreter_Clipboard_SetAsText(var Value: Variant; Args: TJvInterpreterArgs);
+begin
+  var s := string(Args.Values[0]);
+  if Length(s) > 0 then
+    Clipboard.AsText := s
+  else
+    Clipboard.Clear;
 end;
 
 { StrUtils }
@@ -1818,6 +1835,10 @@ begin
     AddConst('Windows', 'SW_SHOWNA', Ord(SW_SHOWNA));
     AddConst('Windows', 'SW_SHOWNOACTIVATE', Ord(SW_SHOWNOACTIVATE));
     AddConst('Windows', 'SW_SHOWNORMAL', Ord(SW_SHOWNORMAL));
+
+    { Clipboard }
+    AddFunction('Vcl.Clipbrd', 'GetClipboardText', JvInterpreter_Clipboard_GetAsText, 0, [varEmpty], varEmpty);
+    AddFunction('Vcl.Clipbrd', 'SetClipboardText', JvInterpreter_Clipboard_SetAsText, 1, [varString], varEmpty);
 
     { StrUtils }
     AddFunction('StrUtils', 'ContainsStr', JvInterpreter_ContainsStr, 2, [varEmpty, varEmpty], varEmpty);


### PR DESCRIPTION
- `GetClipboardText` simply returns `Clipboard.AsText`.
- `SetClipboardText` assigns its single string argument to `Clipboard.AsText`.
- When `SetClipboardText` is passed an empty string, `Clipboard.Clear` is called.

This makes scripts like this possible:

```delphi
{
  Description:
    Add FormList entries by pasting a list of Form IDs delimited by newlines

  Instructions:
    1. In tree view, Shift+Click records that will be added to FormList and press Ctrl+C.
    2. Click FormList record to modify. Press [HOTKEY] to run this script.

  Author:
    fireundubh

  Hotkey: Ctrl+F
}

unit UserScript;

var
  i              : integer;
  sClipboardText : string;
  slFormIDs      : TStringList;

function Initialize: Integer;
var
  s      : string;
  slTemp : TStringDynArray;
begin
  slFormIDs            := TStringList.Create;
  slFormIDs.Sorted     := True;
  slFormIDs.Duplicates := dupIgnore;

  sClipboardText := Trim(GetClipboardText);

  if Length(sClipboardText) = 0 then
    Exit;

  if ContainsText(sClipboardText, #10) then
  begin
    slTemp := SplitString(sClipboardText, #10);

    for i := 0 to Pred(Length(slTemp)) do
    begin
      s := Trim(slTemp[i]);

      if Length(s) = 8 then
        slFormIDs.Append(s);
    end;
  end;
end;

function Process(e: IwbMainRecord): Integer;
var
  x : IwbElement;
  y : IwbElement;
begin
  if Length(sClipboardText) = 0 then
    Exit;

  if slFormIDs.Count = 0 then
    Exit;

  x := ElementByPath(e, 'FormIDs');

  if not Assigned(x) then
    Add(e, 'FormIDs', False);

  x := Add(e, 'FormIDs', False);

  for i := 0 to Pred(slFormIDs.Count) do
  begin
    y := ElementAssign(x, HighInteger, nil, False);
    SetEditValue(y, slFormIDs[i]);
  end;
end;

function Finalize: Integer;
begin
  slFormIDs.Free;
end;

end.
```