### PR TITLE
Updates for FO4 and FO76

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -13829,8 +13829,8 @@ begin
     wbLStringKC(SHRT, 'Short Name', 0, cpTranslate),
     wbEmpty(DATA, 'Marker', cpNormal, True),
     wbStruct(DNAM, '', [
-      wbInteger('Base Health', itU16),
-      wbInteger('Base Action Points', itU16),
+      wbInteger('Calculated Health', itU16),
+      wbInteger('Calculated Action Points', itU16),
       wbInteger('Far Away Model Distance', itU16),
       wbInteger('Geared Up Weapons', itU8),
       wbByteArray('Unused', 1, cpIgnore)

--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -2809,6 +2809,19 @@ begin
     Result := 1;
 end;
 
+function wbINFOGroupDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
+var
+  MainRecord: IwbMainRecord;
+begin
+  Result := 0;
+  MainRecord := aElement.GetContainingMainRecord;
+  if not Assigned(MainRecord) then
+    Exit;
+
+  if (MainRecord.Flags._Flags and $40) > 0 then
+    Result := 1;
+end;
+
 function wbMGEFAssocItemDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
 var
   Container     : IwbContainer;
@@ -8977,16 +8990,47 @@ begin
 
   var wbBoneDataItem :=
     wbRStruct('Data', [
-    wbInteger(BSMP, 'Gender', itU32, wbEnum(['Male', 'Female'])),
-    // should not be sorted!!!
-    wbRArray('Bones',
-      wbRStructSK([0], 'Bone', [
-        wbString(BSMB, 'Name'),
-        wbArray(BSMS, 'Values', wbFloat('Value')).IncludeFlag(dfNotAlignable),
-        wbUnknown(BMMP)
-      ], [])
-    )
-  ], []);
+      wbRArray('Bone Datas',
+        wbRStruct('Bone Data', [
+          wbInteger(BSMP, 'Bone Scale Gender', itU32, wbEnum(['Male', 'Female'])),
+          // should not be sorted!!!
+          wbRArray('Bone Weight Scales',
+            wbRStructSK([0], 'Bone Weight Scale', [
+              wbString(BSMB, 'Name'),
+              wbStruct(BSMS, 'Weight Scale Values', [
+                wbStruct('Thin', [
+                  wbFloat('X'),
+                  wbFloat('Y'),
+                  wbFloat('Z')
+                ]),
+                wbStruct('Muscular', [
+                  wbFloat('X'),
+                  wbFloat('Y'),
+                  wbFloat('Z')
+                ]),
+                wbStruct('Fat', [
+                  wbFloat('X'),
+                  wbFloat('Y'),
+                  wbFloat('Z')
+                ])
+              ])
+            ], [])
+          ),
+          wbInteger(BMMP, 'Bone Modifiers Gender', itU32, wbEnum(['Male', 'Female'])),
+          wbRArray('Bone Modifier',
+            wbRStructSK([0], 'Bone', [
+              wbString(BSMB, 'Name'),
+              wbStruct(BSMS, 'Modifiers', [
+                wbFloat('Min Y'),
+                wbFloat('Min Z'),
+                wbFloat('Max Y'),
+                wbFloat('Max Z')
+              ])
+            ], [])
+          )
+        ],[])
+      )
+    ], []);
 
   wbBSMPSequence := wbRArray('Bone Data', wbBoneDataItem);
 
@@ -11326,11 +11370,11 @@ begin
     wbFloat(NAM0, 'Default Value'), // Prior to form version 81, it was either 0.0, 1.0 or 100.0, so scale or multiplier ?
     wbInteger(AVFL, 'Flags', itU32, wbFlags([ // 32 bits Flags, it used to impact NAM0 loading (bits 10, 11, 12) (even though it loads later :) )
       {0x00000001} 'Unknown 0',
-      {0x00000002} 'Unknown 1',
-      {0x00000004} 'Unknown 2',
+      {0x00000002} 'Skill',
+      {0x00000004} 'Uses Enum',
       {0x00000008} 'Don''t allow Script edits',
-      {0x00000010} 'Unknown 4',
-      {0x00000020} 'Unknown 5',
+      {0x00000010} 'Is Full AV Cached',
+      {0x00000020} 'Is Permanant AV Cached',
       {0x00000040} 'Unknown 6',
       {0x00000080} 'Unknown 7',
       {0x00000100} 'Unknown 8',
@@ -13047,24 +13091,44 @@ begin
     wbEDID,
     wbVMADFragmentedINFO,
     wbStruct(ENAM, 'Response flags', [
-      wbInteger('Flags', itU16, wbFlags([
-        {0x0001} 'Start Scene on End',
-        {0x0002} 'Random',
-        {0x0004} 'Say Once',
-        {0x0008} 'Requires Player Activation',
-        {0x0010} 'Unknown 4',
-        {0x0020} 'Random End',
-        {0x0040} 'End Running Scene',
-        {0x0080} 'ForceGreet Hello',
-        {0x0100} 'Player Address',
-        {0x0200} 'Force Subtitle',
-        {0x0400} 'Can Move While Greeting',
-        {0x0800} 'No LIP File',
-        {0x1000} 'Requires post-processing',
-        {0x2000} 'Audio Output Override',
-        {0x4000} 'Has Capture',
-        {0x8000} 'Unknown 16'
-      ])),
+      wbUnion('Flags', wbINFOGroupDecider,[
+        wbInteger('Flags', itU16, wbFlags([
+          {0x0001} 'Start Scene on End',
+          {0x0002} 'Random',
+          {0x0004} 'Say Once',
+          {0x0008} 'Requires Player Activation',
+          {0x0010} 'Unknown 4',
+          {0x0020} 'Random End',
+          {0x0040} 'End Running Scene',
+          {0x0080} 'ForceGreet Hello',
+          {0x0100} 'Player Address',
+          {0x0200} 'Force Subtitle',
+          {0x0400} 'Can Move While Greeting',
+          {0x0800} 'No LIP File',
+          {0x1000} 'Requires post-processing',
+          {0x2000} 'Audio Output Override',
+          {0x4000} 'Has Capture',
+          {0x8000} 'Unknown 15'
+        ])),
+        wbInteger('Flags', itU16, wbFlags([   //Info groups
+          {0x0001} 'Unknown 0', // Any changes to the idle group removes this flag
+          {0x0002} 'Random',
+          {0x0004} 'Unknown 2', // Any changes to the idle group removes this flag
+          {0x0008} 'Force all children player activate only',
+          {0x0010} 'Unknown 4',
+          {0x0020} 'Random End',
+          {0x0040} 'Unknown 6', // Any changes to the idle group removes this flag
+          {0x0080} 'Unknown 7', // Any changes to the idle group removes this flag
+          {0x0100} 'Child infos don''t inherit reset data',
+          {0x0200} 'Force All Children Random',
+          {0x0400} 'Unknown 10', // Any changes to the idle group removes this flag
+          {0x0800} 'Don''t do all before repeating',
+          {0x1000} 'Unknown 12', // Any changes to the idle group removes this flag
+          {0x2000} 'Unknown 13', // Any changes to the idle group removes this flag
+          {0x4000} 'Unknown 14', // Any changes to the idle group removes this flag
+          {0x8000} 'Unknown 15'
+        ]))
+      ]),
       wbInteger('Reset Hours', itU16, wbDiv(2730))
     ]),
     wbFormIDCk(TPIC, 'Topic', [DIAL]),

--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -339,6 +339,7 @@ const
   CSTY : TwbSignature = 'CSTY';
   CTDA : TwbSignature = 'CTDA';
   CTRG : TwbSignature = 'CTRG'; { New To Fallout 76 }
+  CTRN : TwbSignature = 'CTRN'; { New To Fallout 76 0.2.838.0 }
   CURV : TwbSignature = 'CURV'; { New To Fallout 76 }
   CUSD : TwbSignature = 'CUSD'; { New to Fallout 4 }
   CVPA : TwbSignature = 'CVPA'; { New to Fallout 4 }
@@ -736,6 +737,8 @@ const
   PARW : TwbSignature = 'PARW'; { New to Skyrim }
   PBAR : TwbSignature = 'PBAR'; { New to Skyrim }
   PBEA : TwbSignature = 'PBEA'; { New to Skyrim }
+  PBLT : TwbSignature = 'PBLT'; { New To Fallout 76 0.2.838.0 }
+  PBRT : TwbSignature = 'PBRT'; { New To Fallout 76 0.2.838.0 }
   PCDP : TwbSignature = 'PCDP'; { New To Fallout 76 }
   PCDV : TwbSignature = 'PCDV'; { New To Fallout 76 }
   PCEN : TwbSignature = 'PCEN'; { New To Fallout 76 }
@@ -1380,6 +1383,7 @@ var
   wbPERKData: IwbSubRecordDef;
   wbPerkEffect: IwbSubRecordStructDef;
   wbReward: IwbRecordMemberDef;
+  wbCTRN: IwbSubRecordDef;
 
 function wbGenericModel(aRequired: Boolean = False; aDontShow: TwbDontShowCallback = nil): IwbRecordMemberDef;
 begin
@@ -11157,6 +11161,8 @@ begin
 
   wbBSMPSequence := wbRArray('Bone Data', wbBoneDataItem);
 
+  wbCTRN := wbByteArray(CTRN, 'Unknown CTRN', 13);
+
   var wbEffect :=
     wbRStruct('Effect', [
       wbEFID,
@@ -11288,6 +11294,7 @@ begin
       ])
     ),
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN,
     wbFromSize(1, NVNM, wbNVNMRecordVal, False),
     wbUnknown(MNAM),
     wbNAM1LODP
@@ -11315,6 +11322,7 @@ begin
     wbInteger(FNAM, 'Flags (Unused)', itU16),
     wbCNDCs,
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN,
     wbFormIDCk(GCDA, 'Clobal Cooldown Timer', [GLOB]),
     wbFormIDCk(VNAM, 'Voice Type', [VTYP]),
     wbFormIDCk(FNAM, 'Faction', [FACT])
@@ -12623,12 +12631,14 @@ begin
       wbInteger('No Signal Static', itU8, wbBoolEnum)
     ], cpNormal, False, nil, 4),
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN,
     wbCOCT,
     wbCNTOs,
     wbInteger(LAVT, 'Lookat Value', itU32),
     wbInteger(LAMN, 'Lookat Minimum', itU32),
     wbInteger(LAMX, 'Lookat Maximum', itU32),
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN, //Temporary fix. Figure out how to do this in a way that isn't just duplication
     wbMNAMFurnitureMarker,
     wbStruct(WBDT, 'Workbench Data', [
       wbInteger('Bench Type', itU8, wbEnum([
@@ -12746,6 +12756,7 @@ begin
     wbEDID,
     wbCNAM,
     wbString(DNAM, 'Notes'),
+    wbByteArray(FNAM, 'Unknown FNAM', 4),
     wbInteger(TNAM, 'Type', itU32, wbKeywordTypeEnum),
     wbFormIDCk(DATA, 'Attraction Rule', [AORU]),
     wbFULL
@@ -16649,8 +16660,8 @@ begin
     wbLStringKC(SHRT, 'Short Name', 0, cpTranslate),
     wbEmpty(DATA, 'Marker', cpNormal, True),
     wbStruct(DNAM, '', [
-      wbInteger('Base Health', itU16),
-      wbInteger('Base Action Points', itU16),
+      wbInteger('Calculated Health', itU16),
+      wbInteger('Calculated Action Points', itU16),
       wbInteger('Far Away Model Distance', itU16),
       wbInteger('Geared Up Weapons', itU8),
       wbByteArray('Unused', 1, cpIgnore)
@@ -17477,6 +17488,8 @@ begin
       wbInteger(SNAM, 'Stage to set', itU16),
       wbLString(NAM1, 'Quest Notes'),
       wbString(SCCM, 'Comments'),
+      wbByteArray(PBLT, 'Unknown PBLT', 4),
+      wbByteArray(PBRT, 'Unknown PBRT', 4),
       wbLStringKC(NNAM, 'Display Text', 0, cpTranslate, True),
       wbRArray('Targets', wbRStruct('Target', [
         wbStruct(QSTA, 'Target', [
@@ -19090,6 +19103,7 @@ begin
       'Unknown 6' {Currently Unused}
     ])),
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN,
     wbFormIDCk(PFIG, 'Ingredient', sigBaseObjects),
     wbFormIDCK(SNAM, 'Harvest Sound', [SNDR]),
     wbStruct(PFPC, 'Ingredient Production', [
@@ -20379,6 +20393,7 @@ begin
       'Unknown 6' {Currently Unused}
     ])),
     wbFloat(PAHD, 'Unknown Float'),
+    wbCTRN,
     wbInteger(COCT, 'Holds Holotape (Count)', itU32),
     wbRArray('Holotapes',
       wbStruct(CNTO, 'Holotape', [

--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -1022,6 +1022,7 @@ const
   VNML : TwbSignature = 'VNML';
   VOLI : TwbSignature = 'VOLI'; { New To Fallout 76 }
   VONL : TwbSignature = 'VONL'; { New To Fallout 76 }
+  VREN : TwbSignature = 'VREN'; { New To Fallout 76 }
   VTCK : TwbSignature = 'VTCK';
   VTEX : TwbSignature = 'VTEX';
   VTXT : TwbSignature = 'VTXT';
@@ -12544,6 +12545,7 @@ begin
     wbFormIDCk(VENR, 'Vendor Reset', [GLOB]),
     wbFormIDCk(VENG, 'Vendor Caps Balance', [AVIF]),
     wbFormIDCk(VBCY, 'Vendor Buy Currency', [NULL, CNCY]),
+    wbEmpty(VREN, 'Unknown'),
     wbStruct(VENP, 'Vendor Values', [
       wbInteger('Start Hour', itU16),
       wbInteger('End Hour', itU16),
@@ -13772,8 +13774,8 @@ begin
       {0x00000002} 'Skill',
       {0x00000004} 'Uses Enum',
       {0x00000008} 'Don''t allow Script edits',
-      {0x00000010} 'Unknown 4',
-      {0x00000020} 'Unknown 5',
+      {0x00000010} 'Is Full AV Cached',
+      {0x00000020} 'Is Permanant AV Cached',
       {0x00000040} 'No Modifiers',
       {0x00000080} 'Unknown 7',
       {0x00000100} 'Unknown 8',
@@ -13817,10 +13819,12 @@ begin
       'Unknown'
     ])),
     wbInteger(NAM2, 'Secondary Flags', itU32, wbFlags(wbEmptyBaseFlags, wbFlagsList([
+      {0x00000001}  0, 'Unknown 0',
       {0x00000002}  1, 'First Grouping',
       {0x00000004}  2, 'Unknown 2',
       {0x00000008}  3, 'Network Float Value',
       {0x00000010}  4, 'Only Modified Value',
+      {0x00000020}  5, 'Unknown 5',
       {0x00000040}  6, 'Unknown 6',
       {0x00000080}  7, 'Low Priority'
     ]))),

--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -13836,7 +13836,7 @@ begin
       {0x00000008}  3, 'Network Float Value',
       {0x00000010}  4, 'Only Modified Value',
       {0x00000020}  5, 'Unknown 5',
-      {0x00000040}  6, 'Unknown 6',
+      {0x00000040}  6, 'Only Base Value',
       {0x00000080}  7, 'Low Priority'
     ]))),
     wbFormIDCk(NAM3, 'Actor Value Keyword', [KYWD]), // always a KYWD

--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -13829,10 +13829,10 @@ begin
       'Reputation',
       'Unknown'
     ])),
-    wbInteger(NAM2, 'Secondary Flags', itU32, wbFlags(wbEmptyBaseFlags, wbFlagsList([
+    wbInteger(NAM2, 'Networking Flags', itU32, wbFlags(wbEmptyBaseFlags, wbFlagsList([
       {0x00000001}  0, 'Unknown 0',
-      {0x00000002}  1, 'First Grouping',
-      {0x00000004}  2, 'Unknown 2',
+      {0x00000002}  1, 'Replicate all',
+      {0x00000004}  2, 'Replicate one',
       {0x00000008}  3, 'Network Float Value',
       {0x00000010}  4, 'Only Modified Value',
       {0x00000020}  5, 'Unknown 5',


### PR DESCRIPTION
FO4:
Add union decider for info groups due to the flags being different.
Update the bone datas structure to the same as 76
Update some of the flags in AVFL
Change NPC_/DNAM from Base to Calculated per CK

FO76:
Add FACT/VREN. Currently empty
Add a few AVFL flag defines.
Add some AVIF Secondary flags that are unknowns
Add signatures CTRN, PBLT, and PBRT
Create CTRN structure as a byte array.
Add FACT/FNAM
Update NPC_/DNAM Base values to Calculated.
Add PBLT and PBRT to QUST
add CTRN to ACTI, FLOR, FURN, TERM, TACT