### PR TITLE
FO4: ARMO\FNAM has three padding bytes

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -9269,7 +9269,7 @@ begin
       wbInteger('Armor Rating', itU16),
       wbInteger('Base Addon Index', itU16),
       wbInteger('Stagger Rating', itU8, wbStaggerEnum),
-      wbUnknown(cpIgnore, False, wbNeverShow, nil)
+      wbByteArray('Unused', 3, cpIgnore, false, wbNeverShow)
     ]),
     wbArrayS(DAMA, 'Resistances', wbStructSK([0], 'Resistance', [
       wbFormIDCk('Damage Type', [DMGT]),


### PR DESCRIPTION
- All `ARMO` records in FO4 (checked base game & all DLCs) have three null bytes there.
- Creating a new `ARMO` in the CK adds an `FNAM` that ends with three null bytes.
- Manually using xEdit to get rid of the three null bytes then resaving in the CK adds them back in (though they are now `02 00 00` rather than `00 00 00` - not sure why).
- They bump the subrecord size from 5 to 8, so probably padding.