### PR TITLE
Implement DUAL for FO4

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -12881,6 +12881,19 @@ begin
 
   wbRecord(DUAL, 'Dual Cast Data', [
     wbEDID
+    wbOBND(True),
+    wbStruct(DATA, 'Data', [
+      wbFormIDCk('Projectile', [PROJ, NULL]),
+      wbFormIDCk('Explosion', [EXPL, NULL]),
+      wbFormIDCk('Effect Shader', [EFSH, NULL]),
+      wbFormIDCk('Hit Effect Art', [ARTO, NULL]),
+      wbFormIDCk('Impact Data Set', [IPDS, NULL]),
+      wbInteger('Inherit Scale', itU32, wbFlags([
+        'Hit Effect Art',
+        'Projectile',
+        'Explosion'
+      ]))
+    ], cpNormal, True)
   ]);
 
   wbRecord(SNCT, 'Sound Category', [


### PR DESCRIPTION
Doesn't exist in Fallout4.esm, but can be created in the CK. The resulting file loads fine in TES5Edit if one edits the master to point to Skyrim.esm instead. The format is also identical if viewed in a hex editor.

Test file, created in the FO4 CK: [dualtest.zip](https://github.com/TES5Edit/TES5Edit/files/9393289/dualtest.zip)