### PR TITLE
FO3/FNV: Fix IMGS\DNAM handling

### DIFF
--- a/Core/wbDefinitionsFNV.pas
+++ b/Core/wbDefinitionsFNV.pas
@@ -1945,20 +1945,6 @@ begin
   end;
 end;
 
-function wbIMGSSkinDimmerDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
-var
-  Container : IwbContainer;
-  SubRecord : IwbSubRecord;
-begin
-  Result := 0;
-  if not wbTryGetContainerFromUnion(aElement, Container) then
-    Exit;
-
-  if Supports(Container, IwbSubRecord, SubRecord) then
-    if SubRecord.SubRecordHeaderSize in [132, 148] then
-      Result := 1;
-end;
-
 function wbCOEDOwnerDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
 var
   Container  : IwbContainer;
@@ -7439,10 +7425,7 @@ begin
         {44} wbFloat('Sunlight Dimmer'),
         {48} wbFloat('Grass Dimmer'),
         {52} wbFloat('Tree Dimmer'),
-        {56} wbUnion('Skin Dimmer', wbIMGSSkinDimmerDecider, [
-               wbFloat('Skin Dimmer'),
-               wbEmpty('Skin Dimmer', cpIgnore)
-             ])
+        {56} wbFromVersion(10, wbFloat('Skin Dimmer'))
       ], cpNormal, False, nil, 14),
       wbStruct('Bloom', [
         {60} wbFloat('Blur Radius'),
@@ -7478,17 +7461,17 @@ begin
         {128} wbFloat('Value')
         ])
       ]),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbInteger('Flags', itU8, wbFlags([
+      wbByteArray('Unknown', 4),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(13, wbInteger('Flags', itU8, wbFlags([
         'Saturation',
         'Contrast',
         'Tint',
         'Brightness'
-      ], True)),
-      wbByteArray('Unused', 3)
+      ], True))),
+      wbFromVersion(13, wbByteArray('Unused', 3))
     ], cpNormal, True, nil, 5)
   ]);
 

--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -1844,20 +1844,6 @@ begin
   end;
 end;
 
-function wbIMGSSkinDimmerDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
-var
-  Container : IwbContainer;
-  SubRecord : IwbSubRecord;
-begin
-  Result := 0;
-  if not wbTryGetContainerFromUnion(aElement, Container) then
-    Exit;
-
-  if Supports(Container, IwbSubRecord, SubRecord) then
-    if SubRecord.SubRecordHeaderSize in [132, 148] then
-      Result := 1;
-end;
-
 function wbCOEDOwnerDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
 var
   Container  : IwbContainer;
@@ -7025,10 +7011,7 @@ begin
         {44} wbFloat('Sunlight Dimmer'),
         {48} wbFloat('Grass Dimmer'),
         {52} wbFloat('Tree Dimmer'),
-        {56} wbUnion('Skin Dimmer', wbIMGSSkinDimmerDecider, [
-               wbFloat('Skin Dimmer'),
-               wbEmpty('Skin Dimmer', cpIgnore)
-             ])
+        {56} wbFromVersion(10, wbFloat('Skin Dimmer'))
       ], cpNormal, False, nil, 14),
       wbStruct('Bloom', [
         {60} wbFloat('Blur Radius'),
@@ -7064,17 +7047,17 @@ begin
         {128} wbFloat('Value')
         ])
       ]),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbByteArray('Unused', 4),
-      wbInteger('Flags', itU8, wbFlags([
+      wbByteArray('Unknown', 4),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(10, wbByteArray('Unused', 4)),
+      wbFromVersion(13, wbInteger('Flags', itU8, wbFlags([
         'Saturation',
         'Contrast',
         'Tint',
         'Brightness'
-      ], True)),
-      wbByteArray('Unused', 3)
+      ], True))),
+      wbFromVersion(13, wbByteArray('Unused', 3))
     ], cpNormal, True, nil, 5)
   ]);
 


### PR DESCRIPTION
Bethesda inserted the 'Skin Dimmer' field into the middle of the subrecord. This was done either in form version 10 or 11 - unknown, since there are no IMGS records with form version 10. 11 and above all have it, 9 and below all do not.

Also marked the last five fields form version-dependent - the three unuseds at the end got introduced at the same time as Skin Dimmer, the flags and three unused bytes (almost certainly padding) got introduced in form version 13 or 14 (again, unknown since there are no form version 13 IMGS records - 14 and above all have them, 12 and below all do not).

Without this commit (note e.g. `Night Eye\Tint Color` having a nonsensical blue value of 638):

![image](https://user-images.githubusercontent.com/2845240/188866745-6ed59946-f4ef-42d3-a5d8-207c4dfa41a0.png)

With this commit:

![image](https://user-images.githubusercontent.com/2845240/188867062-9988fe5a-a4e7-4aea-ac3e-92adf5b869fa.png)

View in the GECK (note the night eye color now matching):

![image](https://user-images.githubusercontent.com/2845240/188867407-627d9a5c-d055-4793-b48b-27f47486607c.png)

The data on all the other tabs now lines up as well.