### PR TITLE
SSE: Add LIGH\LNAM

### DIFF
--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -10684,7 +10684,9 @@ begin
       wbFloat('Weight')
     ], cpNormal, True),
     wbFloat(FNAM, 'Fade value', cpNormal, True),
-    wbFormIDCk(SNAM, 'Sound', [SNDR])
+    wbFormIDCk(SNAM, 'Sound', [SNDR]),
+    // SSE
+    wbFormIDCk(LNAM, 'Lens', [LENS])
   ], False, nil, cpNormal, False, wbLIGHAfterLoad);
 end;
 


### PR DESCRIPTION
Same as in FO4, this links a lens flare to a light. Can be set in the CK via the 'Lens Flare' option at the bottom of the Light dialog.
Comes after SNAM, as verified by creating a new record in the CK with both sound and a lens flare and observing the order in which the CK wrote the subrecords.

I tried to use IsSSE for this, but I clearly don't understand it well enough cause it kept saying it couldn't find a working overload for my arguments. So I just followed the same `// SSE` format as the other SSE-exclusive subrecords.