### PR TITLE
Fix assert failure when CalculateFaceNormals is called.

### DIFF
--- a/Core/wbNifMath.pas
+++ b/Core/wbNifMath.pas
@@ -535,7 +535,7 @@ var
   a, b, c, fn: TVector3;
   i: Integer;
 begin
-  SetLength(norms, Length(triangles) * SizeOf(TTriangle));
+  SetLength(norms, Length(verts));
   Assert(Length(norms) = Length(verts));
   for i := Low(triangles) to High(triangles) do begin
     a := verts[triangles[i][0]];


### PR DESCRIPTION
The previous logic was setting crazy high array size and would never pass the assert check.