### PR TITLE
Add "list winning override references" edit script

### DIFF
--- a/Build/Edit Scripts/List winning override references.pas
+++ b/Build/Edit Scripts/List winning override references.pas
@@ -1,0 +1,17 @@
+unit WinningOverrideReferences;
+
+function Process(e: IInterface): Integer;
+var
+  m, r: IInterface;
+  i: Integer;
+begin
+  m := MasterOrSelf(e);
+  for i := 0 to Pred(ReferencedByCount(m)) do begin
+    r := ReferencedByIndex(m, i);
+    if IsWinningOverride(r) then
+      AddMessage(GetFileName(r) + #9 + Name(r));
+  end;
+    
+end;
+
+end.


### PR DESCRIPTION
I have zero credit in this, script is by @zilav from [this comment](https://github.com/TES5Edit/TES5Edit/issues/822#issuecomment-673275540) and I literally just copy-pasted it.

I found it super helpful and thought it would be awesome to include as a default script. 
