### PR TITLE
TES4: Add support for ACRE\XLOD

### DIFF
--- a/Core/wbDefinitionsTES4.pas
+++ b/Core/wbDefinitionsTES4.pas
@@ -1895,8 +1895,9 @@ begin
     wbEDID,
     wbFormIDCk(NAME, 'Base', [CREA], False, cpNormal, True),
     wbOwnership(wbXOWN, [], wbXGLB),
-    wbXESP,
     wbXRGD,
+    wbXLOD,
+    wbXESP,
     wbXSCL,
     wbDATAPosRot
   ], True, wbPlacedAddInfo);


### PR DESCRIPTION
Same as `ACHR` and `REFR`, `ACRE` can also have an `XLOD` subrecord in Oblivion. For an example, see [Landmarks of Cyrodiil Lite](https://www.nexusmods.com/oblivion/mods/51064).

I edited a record from that plugin in the CS, making it dump out all subrecords to see the exact order in which the CS puts them out for `ACRE`, hence the change in position for `XESP`.