### PR TITLE
FO4: MO*F are first-person/facebone flags

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -926,6 +926,7 @@ var
   wbDESCReq: IwbSubRecordDef;
   wbXSCL: IwbSubRecordDef;
   wbMODC: IwbSubRecordDef;
+  wbModelFlags: IwbFlagsDef;
   wbMODF: IwbSubRecordDef;
   wbMODS: IwbSubRecordDef;
   wbMO2S: IwbSubRecordDef;
@@ -7475,11 +7476,15 @@ begin
   wbMO4S := wbFormIDCk(MO4S, 'Material Swap', [MSWP]);
   wbMO5S := wbFormIDCk(MO5S, 'Material Swap', [MSWP]);
 
-  wbMODF := wbUnknown(MODF);
-  wbMO2F := wbUnknown(MO2F);
-  wbMO3F := wbUnknown(MO3F);
-  wbMO4F := wbUnknown(MO4F);
-  wbMO5F := wbUnknown(MO5F);
+  wbModelFlags := wbFlags([
+    'Has FaceBones Model',
+    'Has 1stPerson Model'
+  ]);
+  wbMODF := wbInteger(MODF, 'Flags', itU8, wbModelFlags);
+  wbMO2F := wbInteger(MO2F, 'Flags', itU8, wbModelFlags);
+  wbMO3F := wbInteger(MO3F, 'Flags', itU8, wbModelFlags);
+  wbMO4F := wbInteger(MO4F, 'Flags', itU8, wbModelFlags);
+  wbMO5F := wbInteger(MO5F, 'Flags', itU8, wbModelFlags);
 
   wbMODC := wbFloat(MODC, 'Color Remapping Index');
   wbMO2C := wbFloat(MO2C, 'Color Remapping Index');


### PR DESCRIPTION
Created via the CK function 'Character > Update FaceBones Model Availability' (well, the `_faceBones` value is - not sure about the `1stPerson` value, see below).

Seems to have a value of 1 whenever a model has an `_faceBones` model available and 2 whenever it has a `1stPerson` model available.
Could also be an enum, I couldn't find any examples of models that have both in vanilla FO4, but the name (MOD*F*, MO2*F*, etc.) makes me think flags are more likely.
CommonLibF4 also calls it 'flags', but does not seem to have its values decoded.