### PR TITLE
Starfield: completed AMDL (Aim Model) definition

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -17458,27 +17458,24 @@ begin
   {subrecords checked against Starfield.esm}
   wbRecord(AMDL, 'Aim Model', [
     wbEDID,
-    wbUnknown(ANAM)
-    {
-    wbStruct(DNAM, 'Data', [
-      wbFloat('Cone of Fire - Min Angle'),
-      wbFloat('Cone of Fire - Max Angle'),
-      wbFloat('Cone of Fire - Increase Per Shot'),
-      wbFloat('Cone of Fire - Decrease Per Sec'),
-      wbInteger('Cone of Fire - Decrease Delay MS', itU32),
-      wbFloat('Cone of Fire - Sneak Mult'),
-      wbFloat('Recoil - Diminish Spring Force'),
-      wbFloat('Recoil - Diminish Sights Mult'),
-      wbFloat('Recoil - Max Per Shot'),
-      wbFloat('Recoil - Min Per Shot'),
-      wbFloat('Recoil - Hip Mult'),
-      wbInteger('Runaway - Recoil Shots', itU32),
-      wbFloat('Recoil - Arc'),
-      wbFloat('Recoil - Arc Rotate'),
-      wbFloat('Cone of Fire - Iron Sights Mult'),
-      wbFloat('Stability - Base Stability')
+    wbStruct(ANAM, 'Data', [
+       wbFloat('Cone of Fire - Min Angle'),
+       wbFloat('Cone of Fire - Max Angle'),
+       wbFloat('Cone of Fire - Increase Per Shot'),
+       wbFloat('Cone of Fire - Decrease Per Sec'),
+       wbFloat('Cone of Fire - Decrease Delay in Sec'),
+       wbFloat('Cone of Fire - Sneak Mult'),
+       wbFloat('Recoil - Diminish Spring Force'),
+       wbFloat('Recoil - Diminish Sights Mult'),
+       wbFloat('Recoil - Min Per Shot'),
+       wbFloat('Recoil - Max Per Shot'),
+       wbFloat('Recoil - Hip Mult'),
+       wbInteger('Runaway - Recoil Shots', itU32),
+       wbFloat('Recoil - Arc'),
+       wbFloat('Recoil - Arc Rotate'),
+       wbFloat('Cone of Fire - Iron Sights Mult'),
+       wbFloat('Stability - Base Stability')
     ])
-    }
   ]);
 
   {subrecords checked against Starfield.esm}


### PR DESCRIPTION
Differences between FO4 AMDL definition and SF1 AMDL definition:
- 'Cone of Fire - Decrease Delay' bytes now refer to float measuring seconds, instead of integer U32 measuring milliseconds
- Positions of 'Recoil - Min Per Shot' and 'Recoil - Max Per Shot' now swapped - Min Per Shot now appears before Max Per Shot