### PR TITLE
Starfield: planet worldspace positions are lat/lon in radians

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -18954,8 +18954,8 @@ end;
     wbArray(CNAM, 'Worldspaces',
       wbStruct('Worldspace', [
         wbStruct('Position', [
-          wbDouble,
-          wbDouble
+          wbDouble('Latitude (radians)'),
+          wbDouble('Longitude (radians)')
         ]),
         wbFormIDCk('Worldspace', [WRLD])
       ])

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -7956,8 +7956,9 @@ end;
             ]),
             //UniquePatternPlacementInfo_Component
              wbStruct('', [
-              wbFormIDCK('Unknown', [PNDT, NULL]),
-              wbUnknown                              //possibly a pair of doubles as Longitude and lattitude in radians
+              wbFormIDCK('Planet', [PNDT, NULL]),
+              wbDouble('Longitude (radians)'),
+              wbDouble('Latitude (radians)')
             ])
           ]).IncludeFlag(dfUnionStaticResolve)
         ], []),


### PR DESCRIPTION
Spot-checked against various Earth locations by converting the "unknown" doubles from radians to degrees; they ain't *perfect* matches (for example, Osaka's real lat/lon are 34.672314,135.484802 while Osaka's in-game lat/lon convert to 34.9051318854,135.7256001305), but they're within a tight enough margin of error that I'm reasonably confident these are indeed latitudes and longitudes.