### PR TITLE
Expose GetAssignTemplates to scripts

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -7954,7 +7954,7 @@ end;
       ])),
       wbRUnion('Component Data', [
         //BGSAnimationGraph_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #0', [
           wbString(ANAM, 'Animation Root'),
           wbString(BNAM, 'Skeleton'),
           wbString(CNAM, 'Animations'),
@@ -7962,14 +7962,14 @@ end;
           wbString(ENAM)
         ], []),
         //BGSAttachParentArray_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #1', [
           wbAPPR
         ], []),
         //BGSActivityTracker
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #2', [
           wbActivityTracker
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #3', [
           wbArray(BUO4, 'Blue Print Components',
             wbStruct('Item', [
               wbFormIDCk('Base Item', [GBFM]),
@@ -8008,7 +8008,7 @@ end;
           wbInteger(BOID, 'Next Part ID', itU32)
         ], []),
         //BGSCrowdComponent_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #4', [
           wbFloat(CDND),
           wbUnknown(CDNS),
           wbRStructs('Unknown', 'Unknown', [
@@ -8019,11 +8019,11 @@ end;
             wbFloat(FLTV)
           ], [])
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #5', [
           wbContainerItems
         ], []),
 
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #6', [
           wbUnion(DAT2, 'Data', wbBFCDAT2Decider, [
             wbUnknown,
             //BlockHeightAdjustment_Component
@@ -8043,7 +8043,7 @@ end;
         ], []),
         //BGSStarDataComponent_Component
         //BGSOrbitedDataComponent_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #7', [
           wbUnion(DATA, 'Data', wbBFCDATADecider, [
             wbUnknown,
             //BGSStarDataComponent_Component
@@ -8109,7 +8109,7 @@ end;
           ]).IncludeFlag(dfUnionStaticResolve)
         ], []),
         //BGSDisplayCase
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #8', [
           wbArray(DCSD, 'Unknown', wbStruct('Unknown', [
             wbFormIDCk('Display Filter', [FLST]),
             wbUnknown(4),
@@ -8118,15 +8118,15 @@ end;
           ])),
           wbArray(DCED, 'Unknown', wbUnknown(4))
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #9', [
           wbDest
         ], []),
         //BGSSpaceshipEquipment_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #10', [
           wbUnknown(ESSF)
         ], []),
         //BGSExternalComponentDataSource_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #11', [
           wbFormIDCk(EXDC, 'External Base Template', [NULL, GBFM, LVLB]),
           wbRStruct('External Data Sources', [
             wbInteger(EXDZ, 'Data Source Count', itU32), // count for EXCN/EXCI struct array
@@ -8144,11 +8144,11 @@ end;
           wbString(EXBS).SetRequired
         ], []),
         //BGSLinkedVoiceType_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #12', [
           wbFormIDCk(FCTF, 'Voice Type', [NULL, VTYP])
         ], []),
         //BGSContactShadowComponent_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #13', [
           wbStruct(FLCS, 'Unknown', [
             wbFloat,
             wbFloat,
@@ -8157,46 +8157,46 @@ end;
             wbFloat
           ])
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #14', [
           wbFLLD
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #15', [
           wbFTYP
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #16', [
           wbFULL
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #17', [
           wbUnknown(GNAM)
         ], []),
         //BGSSpaceshipHullCode_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #18', [
           wbLStringKC(HULL, 'Hull Code', 0, cpTranslate)
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #19', [
           wbFormIDCk(INAM, 'Add to inventory on destroy', [LVLI])
         ], []),
         //BGSObjectWindowFilter_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #20', [
           wbUnknown(INTV),
           wbString(FLTR, 'Filter')
         ], []),
         //BGSFormLinkData_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #21', [
           wbInteger(ITMC, 'Count', itU32),
           wbRArray('Linked Forms', wbRStruct('Linked Form', [
             wbFormIDCk(FLKW,'Keyword', [KYWD]),
             wbFormID(FLFM, 'Linked Form')
           ], []))
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #22', [
           wbKeywords
         ], []),
         //TESImageSpaceModifiableForm_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #23', [
           wbFormIDCk(MNAM, 'Image Space Adapter', [IMAD])
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #24', [
           wbString(MODL, 'Model'),
           wbFLLD,
           wbStruct(XMPM, 'Unknown', [
@@ -8212,52 +8212,52 @@ end;
           wbString(XMSP, 'Ring material'),
           wbString(XLMS, 'Ring id')
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #25', [
           wbOPDS
         ], []),
         //HoudiniData_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #26', [
           wbReflection(PCCC)
         ], []),
         //BGSPropertySheet_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #27', [
           wbPRPS
         ], []),
         //ParticleSystem_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #28', [
           wbReflection(PTCL)
         ], []),
         //BGSLodOwner_Component
         //BGSEffectSequenceComponent
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #29', [
           wbREFL
         ], []),
         //BGSSpaceshipAIActor_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #30', [
           wbFormIDCk(SAIA, 'Spaceship AI Actor', [NPC_])
         ], []),
         //BGSSpaceshipWeaponBindings_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #31', [
           wbStruct(SHWB, 'Ship Weapon Binding', [
             wbInteger('Weapon Slot 1', itS32).SetLinksToCallback(wbLinksToBluePrintComponent).SetToStr(wbToStringFromLinksToSummary),
             wbInteger('Weapon Slot 2', itS32).SetLinksToCallback(wbLinksToBluePrintComponent).SetToStr(wbToStringFromLinksToSummary),
             wbInteger('Weapon Slot 3', itS32).SetLinksToCallback(wbLinksToBluePrintComponent).SetToStr(wbToStringFromLinksToSummary)
           ])
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #32', [
           wbUnknown(SNAM),
           wbUnknown(PNAM),
           wbFormIDCk(BNAM, 'Surface Block', [SFBK])
         ], []),
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #33', [
           wbFormIDCk(SODA, 'Spawn on destroy', sigBaseObjects)
         ], []),
         //BGSSoundTag_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #34', [
           wbSTCP
         ], []),
         //BGSStoredTraversals_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #35', [
           wbStruct(STRD, 'Stored Traversal Data', [
             wbArray('Unknown', wbTraversalData, -1)
             .IncludeFlag(dfFastAssign)
@@ -8284,7 +8284,7 @@ end;
           .IncludeFlag(dfFastAssign)
         ], []),
         //Volumes_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #36', [
           wbStruct(VLMS, 'Unknown', [
             wbArray('Unknown', wbStruct('Unknown', [
               wbInteger('Type', itU32, wbEnum([], [
@@ -8324,7 +8324,7 @@ end;
           ])
         ], []),
         //BGSPlanetContentManagerContentProperties_Component
-        wbRStruct('Component Data', [
+        wbRStruct('Component Data #37', [
           wbUnknown(ZNAM, 4),
           wbUnknown(YNAM, 1),
           wbUnknown(XNAM, 4),

--- a/xEdit/JvI/xejviScriptAdapter.pas
+++ b/xEdit/JvI/xejviScriptAdapter.pas
@@ -694,6 +694,34 @@ begin
     Value := Element.GetSummary;
 end;
 
+procedure IwbElement_AssignTemplateCount(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  Element: IwbElement;
+begin
+  var elementIdx := Integer(Args.Values[1]);
+  if Supports(IInterface(Args.Values[0]), IwbElement, Element) then
+  begin
+    var templates := Element.GetAssignTemplates(elementIdx);
+    Value := Length(templates);
+  end;
+end;
+
+procedure IwbElement_AssignTemplateByIndex(var Value: Variant; Args: TJvInterpreterArgs);
+var
+  Element: IwbElement;
+begin
+  var elementIdx := Integer(Args.Values[1]);
+  var templateIdx := Integer(Args.Values[2]);
+  if Supports(IInterface(Args.Values[0]), IwbElement, Element) then
+  begin
+    var list := TList.Create;
+    var templates := Element.GetAssignTemplates(elementIdx);
+
+    if (templateIdx >= Low(templates)) and (templateIdx <= High(templates)) then
+      Value := IInterface(templates[templateIdx]);
+  end;
+end;
+
 procedure _wbCopyElementToFile(var Value: Variant; Args: TJvInterpreterArgs);
 var
   Element: IwbElement;
@@ -2054,6 +2082,8 @@ begin
     AddFunction(cUnit, 'BeginUpdate', IwbElement_BeginUpdate, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'EndUpdate', IwbElement_EndUpdate, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'GetSummary', IwbElement_GetSummary, 1, [varEmpty], varEmpty);
+    AddFunction(cUnit, 'AssignTemplateCount', IwbElement_AssignTemplateCount, 2, [varEmpty, varInteger], varEmpty);
+    AddFunction(cUnit, 'AssignTemplateByIndex', IwbElement_AssignTemplateByIndex, 3, [varEmpty, varInteger, varInteger], varEmpty);
 
     { IwbContainer }
     AddFunction(cUnit, 'GetElementEditValues', IwbContainer_GetElementEditValues, 2, [varEmpty, varString], varEmpty);


### PR DESCRIPTION
```delphi
component     := ElementByPath(rec, 'Components\[0]');     // Components\[0] = element
template      := AssignTemplateByIndex(component, 1, 29);  // Components\[0]\[1] = union, 29 = Component Data #29
templateCount := AssignTemplateCount(component, 1);        // returns array length
```
Unfortunately, arrays have to be handled this way in JvInterpreter. That's why these functions were implemented:

- `MasterCount`/`MasterByIndex`
- `RecordCount`/`RecordByIndex`
- `ElementCount`/`ElementByIndex`
- `ReferencedByCount`/`ReferencedByIndex`
- `ReferencesByCount`/`ReferencesByIndex`
- `OverrideCount`/`OverrideByIndex`