### PR TITLE
Bypass circular masters check with expert user argument

### DIFF
--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -4068,7 +4068,8 @@ begin
         if not Assigned(Rec) then
           raise Exception.CreateFmt('Unexpected error reading master list for file "%s"', [flFileName]);
         if not wbStripEmptyMasters or (Trim(Rec.EditValue) <> '') then
-          aMasters.Add(Rec.EditValue);
+          if not wbStripMasters or (wbStripMasters and wbStripMastersFileNames.Find(Rec.EditValue, i) = False) then
+            aMasters.Add(Rec.EditValue);
       end;
   end else
     for i := Low(flMasters) to High(flMasters) do
@@ -4894,7 +4895,8 @@ begin
         if not Assigned(Rec) then
           raise Exception.CreateFmt('Unexpected error reading master list for file "%s"', [flFileName]);
         if not wbStripEmptyMasters or (Trim(Rec.EditValue) <> '') then
-          AddMaster(Rec.EditValue, False, flLoadOrder = High(Integer));
+          if not wbStripMasters or (wbStripMasters and wbStripMastersFileNames.Find(Rec.EditValue, i) = False) then
+            AddMaster(Rec.EditValue, False, flLoadOrder = High(Integer));
       end;
 
     s := Header.ElementEditValues['SNAM'].ToLower;

--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -179,6 +179,8 @@ var
   wbEditInfoUseShortName             : Boolean    = False;
   wbDevMode                          : Boolean    = False;
   wbStripEmptyMasters                : Boolean    = False;
+  wbStripMasters                     : Boolean    = False;
+  wbStripMastersFileNames            : TStringList;
   wbAlwaysSorted                     : Boolean    = False;
   wbThemesSupported                  : Boolean    = True;
   wbReportModGroups                  : Boolean    = False;

--- a/xEdit/xeInit.pas
+++ b/xEdit/xeInit.pas
@@ -1006,13 +1006,31 @@ begin
       wbAllowDirectSave := True;
 
   if FindCmdLineSwitch('IKnowWhatImDoing') then
+  begin
     wbIKnowWhatImDoing := True;
 
-  if wbIKnowWhatImDoing and FindCmdLineSwitch('AllowMasterFilesEdit') then
-    wbAllowMasterFilesEdit := True;
+    if FindCmdLineSwitch('AllowMasterFilesEdit') then
+      wbAllowMasterFilesEdit := True;
 
-  if wbIKnowWhatImDoing and FindCmdLineSwitch('StripEmptyMasters') then
-    wbStripEmptyMasters := True;
+    if FindCmdLineSwitch('StripEmptyMasters') then
+      wbStripEmptyMasters := True;
+
+    if wbFindCmdLineParam('StripMasters', s) then
+    begin
+      wbStripMasters := True;
+
+      wbStripMastersFileNames := TStringList.Create;
+      wbStripMastersFileNames.Sorted := True;
+      wbStripMastersFileNames.Duplicates := dupIgnore;
+      wbStripMastersFileNames.AddStrings(s.Split([',']).ForEach(Trim).RemoveEmpty);
+
+      if wbStripMastersFileNames.Count < 1 then
+      begin
+        FreeAndNil(wbStripMastersFileNames);
+        wbStripMasters := False;
+      end;
+    end;
+  end;
 
   if wbToolMode = tmEdit then begin
     if   FindCmdLineSwitch('quickshowconflicts') or FindCmdLineSwitch('qsc')


### PR DESCRIPTION
Regardless of whether the advanced switches are enabled, scripts can always add self-referencing masters to plugins.

If you forget or don't notice the master needs to be removed - or you can't remove that master in the same session - the solution shouldn't involve recompiling xEdit.

This "in case of emergency" switch allows users who know what they're doing (there are no bumpers!) to attempt a rescue.

The argument takes a string: `-StripMasters:RemoveThisPlugin.esm,AndThisOne.esm,OhAndThisOneToo.esm`. Works exactly like `-StripEmptyMasters` otherwise.