### PR TITLE
Various `NPC_` field relabels

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -14521,7 +14521,7 @@ end;
     wbFormIDCk(SOFT, 'Space Outfit', [OTFT], False, cpNormal, False),
     wbFormIDCk(DPLT, 'Default Package List', [FLST], False, cpNormal, False),
     wbFormIDCk(CRIF, 'Crime Faction', [FACT], False, cpNormal, False),
-    wbFormIDCk(HEFA, 'Unknown', [FACT]),
+    wbFormIDCk(HEFA, 'Formation Faction', [FACT]),
     wbInteger(EDCT, 'Tint Count', itU8, nil, cpBenign),
     wbRArray('Tints',
       wbRStruct('Tint', [

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -14518,7 +14518,7 @@ end;
       wbFormIDCk(BNAM, 'Unknown', [DLBR])
     ], []),
     wbFormIDCk(DOFT, 'Default Outfit', [OTFT], False, cpNormal, False),
-    wbFormIDCk(SOFT, 'Sleeping Outfit', [OTFT], False, cpNormal, False),
+    wbFormIDCk(SOFT, 'Space Outfit', [OTFT], False, cpNormal, False),
     wbFormIDCk(DPLT, 'Default Package List', [FLST], False, cpNormal, False),
     wbFormIDCk(CRIF, 'Crime Faction', [FACT], False, cpNormal, False),
     wbFormIDCk(HEFA, 'Unknown', [FACT]),

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -14513,9 +14513,9 @@ end;
     ], []),
     wbFormIDCk(CSCR, 'Inherits Sounds From', [NPC_], False, cpNormal, False),
 //    wbFormIDCk(PFRN, 'Power Armor Stand', [FURN]),
-    wbRStruct('Unknown', [
-      wbFormIDCk(QSTA, 'Unknown', [QUST]),
-      wbFormIDCk(BNAM, 'Unknown', [DLBR])
+    wbRStruct('Companion Info', [
+      wbFormIDCk(QSTA, 'Quest', [QUST]),
+      wbFormIDCk(BNAM, 'Dialogue', [DLBR])
     ], []),
     wbFormIDCk(DOFT, 'Default Outfit', [OTFT], False, cpNormal, False),
     wbFormIDCk(SOFT, 'Space Outfit', [OTFT], False, cpNormal, False),


### PR DESCRIPTION
Spot-checked a bunch of `NPC_` records and ended up with a few findings, which this PR reflects:

- The "Unknown" `QSTA`/`BNAM` pair is consistently a companion quest and companion dialogue tree (seemingly the idle chatter when doing stuff like picking up objects and taking chems); relabeled the struct and members accordingly
- The "Sleep Outfit" (`SOFT`) is consistently a spacesuit, not sleepwear; relabeled to "Space Outfit" to reflect that.  It's possible sleepwear is still defined elsewhere, but given that NPCs don't change into their spacesuits before going to bed this is probably worth renaming 😉 
- The "Unknown" `HEFA` is consistently used to specify a faction designating a "group", "formation", or "herd" - i.e. for when multiple NPCs should move together in a specific way (e.g. groups of Ecliptic/Va'ruun outside their ships, "Trained Aceles" and their handlers after the Vanguard main quest, etc.)
  - I have a hunch that the `HERD` subrecords on certain `FACT`s are related to this; maybe those "unknown" values are for spacing and arranging the group members?
  - I'm willing to bet "HEFA" stands for "HErd FAction"; tentatively named it "Formation Faction" in this PR since the factions used ain't always "herds" *per se*, but I wouldn't be surprised if "Herd Faction" ends up being the right name
  - Only 17 NPCs seem to have a formation faction specified this way