### PR TITLE
Starfield: Sensible defaults for Object Mod Template Items

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -8721,7 +8721,7 @@ end;
     wbInteger('Level Min', itU16),
     wbInteger('Level Max', itU16),
     wbInteger('Addon Index', itS16).SetDefaultNativeValue(-1),
-    wbInteger('Default', itU8, wbBoolEnum),
+    wbInteger('Default', itU8, wbBoolEnum).SetDefaultNativeValue(1),
     wbArray('Keywords', wbFormIDCk('Keyword', [KYWD, NULL]), -4),
     wbInteger('Min Level For Ranks', itU8),
     wbInteger('Alt Levels Per Tier', itU8),

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -8720,7 +8720,7 @@ end;
     wbInteger(csPropertyCount, itU32),
     wbInteger('Level Min', itU16),
     wbInteger('Level Max', itU16),
-    wbInteger('Addon Index', itS16),
+    wbInteger('Addon Index', itS16).SetDefaultNativeValue(-1),
     wbInteger('Default', itU8, wbBoolEnum),
     wbArray('Keywords', wbFormIDCk('Keyword', [KYWD, NULL]), -4),
     wbInteger('Min Level For Ranks', itU8),


### PR DESCRIPTION
Findings from repeatedly crashing Starfield over and over again for fun and profit:

- At least one `OBTS` for a `WEAP` (and probably for other records, e.g. `ARMO`; I haven't tested that yet) **must** have "Addon Index" set to -1 and "Default" set to "True", or else Starfield will crash:
  - Usually the crash happens upon creating an instance of the item with the faulty object template list
  - Sometimes the crash happens in the main menu, a few seconds after pressing any key to continue; this only seemed to trigger after renaming the faulty ESM (but fixing the ESM fixed the crash)
  - In one case (specifically with no `OBTS` set as default, but with two with an Addon Index of -1), the crash happened about a second after opening the player's inventory, even without having added the faulty `WEAP` to it
- Having multiple `OBTS`s with "Addon Index" = -1 and/or "Default" = True has no apparent adverse effects, so it's safe (AFAICT) for these values to be defaults for a newly-created / otherwise-empty `OBTS`

Open questions:

- Do other records with `OBTS`s (e.g. `ARMO`s) also cause crashes if there's no `OBTS` set as default with an Addon Index of -1?
- Does this crash affect other games (e.g. Fallout 4) as well, or is it unique to Starfield?