### PR TITLE
FO3, FNV: Fix Masser/Secunda display

### DIFF
--- a/Core/wbDefinitionsFNV.pas
+++ b/Core/wbDefinitionsFNV.pas
@@ -769,8 +769,8 @@ begin
 
   if aType in [ctToStr, ctToSummary] then begin
     PhaseLength := aInt mod 64;
-    Masser := (aInt and 64) <> 0;
-    Secunda := (aInt and 128) <> 0;
+    Secunda := (aInt and 64) <> 0;
+    Masser := (aInt and 128) <> 0;
     if Masser then
       if Secunda then
         Result := 'Masser, Secunda / '

--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -752,8 +752,8 @@ begin
 
   if aType in [ctToStr, ctToSummary] then begin
     PhaseLength := aInt mod 64;
-    Masser := (aInt and 64) <> 0;
-    Secunda := (aInt and 128) <> 0;
+    Secunda := (aInt and 64) <> 0;
+    Masser := (aInt and 128) <> 0;
     if Masser then
       if Secunda then
         Result := 'Masser, Secunda / '


### PR DESCRIPTION
Apparently Bethesda decided to swap the bits these two use in FO3.

Closes #1027