### PR TITLE
Starfield: name some of the currently-unknwon `RACE` fields

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -16341,7 +16341,7 @@ end;
       ], [])
     ], []),
 
-    wbLString(SNAM, 'Unknown', 0, cpTranslate)
+    wbLString(SNAM, 'Plural Name', 0, cpTranslate)
 
   ]);
 

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -16333,7 +16333,7 @@ end;
       ], [], cpNormal, True)
     ], []),
 
-    wbRStructs('Unknown', 'Unknown', [
+    wbRStructs('Mannequin Skin Swaps', 'Skin Swap', [
       wbUnknown(MSSS),
       wbRStructs('Unknown', 'Unknown', [
         wbUnknown(MSSI),


### PR DESCRIPTION
# Identified Fields

## SNAM - Plural Name

Only used 4 times in `Starfield.esm`:

- Human -> Humans (in `HumanRace`, `ChildRace`, and `HumanCrowdRace`)
- Human Corpse -> Human Corpses (in `HumanCorpseRace`)
- Mannequin -> Mannequins (in `MannequinRace`)
- MiniBotA -> minibota (in `MiniBotARace`)

## Mannequin Skin Swaps

Only used by `MannequinRace`, and only to specify apparent indices into (or flags on?) `LMS_Mannequin_SkinSwap` referenced in the `MSSA`, hence the name.

- "MSS" probably stands for "Mannequin Skin Swap"
- Not sure what `MSSS` stands for ("Mannequin Skin Swap Skin"?) or what it is (maybe an index?)
- I'd guess `MSSI` stands for "Mannequin Skin Swap Index"
- Not sure what `MSSA` stands for ("Mannequin Skin Swap Assignment"?)

Probably won't be able to glean much more from this one until `REFL`s are more fully decoded.

# Open questions

Leaving these as notes for the next person to take a crack at deciphering these fields (that person may or may not be future me).

<details><summary>Lots of rambling; click to expand</summary>
<p>

## DAT2

### Flag: Unknown 46

All `RACE`s in `Starfield.esm` have it except for the following:

- `SecurityCameraRace`
- `BallisticTurretRace`
- `LaserTurretRace`

Does Unknown 46 mean "not a turret"?  Maybe something about being completely stationary?

### Flag: Unknown 55

All `RACE`s in `Starfield.esm` have it except for the following:

- `CritterRace`
- `AutopilotRace`
- `FloaterARace`
- `ModelTRace`
- `SecurityCameraRace`
- `BallisticTurretRace`
- `LaserTurretRace`
- `MannequinRace`
- `MiniBotARace`
- `FlyerARace`
- `SwimmerARace`
- `MantaARace`
- `LarvaARace`
- `ParasiteARace`

Not sure what the commonality here is.

### Flag: Unknown 57

Only 3 `RACE`s have it:

- `TerrormorphRace`
- `ParasiteARace`
- `TerrormorphElderRace`

Probably has something to do with Terrormorphs.

### Flag: Unknown 58

Only `HopperARace` has it.

### "Unknown"s

#### Offset 52

Always one of two values:

- `02 00 00 00` (`HumanRace`, `HumanCorpseRace`, `MannequinRace`, `ChildRace`)
- `FF FF FF FF` (every other `RACE`)

#### Offset 56

Always one of three values:

- `00 00 00 00` (`HumanRace`, `ChildRace`)
- `01 00 00 00` (`HumanCrowdRace`)
- `FF FF FF FF` (every other `RACE`)

#### Offset 60

Always one of two values:

- 0.01 (`HumanRace`, `HumanCorpseRace`, `ChildRace`, `HumanCrowdRace`)
- 0.0 (every other `RACE`)

Comment in `wbDefinitionsSF1` mentions this "must have to do with unarmed weapon".

#### Offset 76

Known values:

- 0.0 (`HumanCorpseRace`, `ModelTRace`, `BallisticTurretRace`, `LaserTurretRace`, `MannequinRace`, `TerrormorphRace`, `MantidARace`, `TerrormorphElderRace`)
- 10.0 (`ModelSRace`)
- 20.0 (`ModelARace`, `HopperARace`, `OctopedeARace`, `CritterRace`, `FloaterARace`, `CCT_DummyRace`, `MiniBotARace`, `BipedARace`, `FlyerARace`, `QuadrupedCRace`, `MantaARace`, `LarvaARace`, `ParasiteARace`, `HexapodARace`, `QuadrupedBRace`)
- 30.0 (`HumanRace`, `AutopilotRace`, `QuadrupedARace`, `ChildRace`, `HumanCrowdRace`)
- 180.0 (`SecurityCameraRace`)

Are these angles in degrees?

#### Offset 80

Always `00 00 00 00`.

#### Offset 84

Known values:

- 1.0 (`ModelARace`, `ModelSRace`, `MantaARace`)
- 0.75 (`TerrormorphElderRace`)
- 0.25 (all other `RACE`s)

#### Offset 88

Known values:

- 5.0 (`OctopedeARace`, `CritterRace`, `FloaterRace`, `ModelTRace`, `SecurityCameraRace`, `CCT_DummyRace`, `BallisticTurretRace`, `LaserTurretRace`, `MannequinRace`, `MiniBotARace`, `LarvaARace`, `ParasiteARace`, `HexapodARace`)
- 15.0 (`ModelARace`, `ModelSRace`, `TerrormorphRace`, `SwimmerARace`, `MantaARace`, `TerrormorphElderRace`)
- 30.0 (`HopperARace`)
- 45.0 (`HumanRace`, `AutopilotRace`, `HumanCorpseRace`, `FlyerARace`, `QuadrupedCRace`, `MantidARace`, `ChildRace`, `HumanCrowdRace`)
- 60.0 (`QuadrupedARace`, `QuadrupedBRace`)
- 80.0 (`BipedARace`)

Are these angles in degrees?

#### Offsets 92 through 116

Always `00 00 00 00`.

#### Offset 120

Known values:

- 0.0 (`SecurityCameraRace`, `BallisticTurretRace`, `LaserTurretRace`, `MannequinRace`)
- -300.0 (all other `RACE`s)

#### Offset 124

Always `00 00 00 00`.

#### Offset 128

Always `FF FF FF FF`

#### Offset 132

Always `00 00`.

#### Offset 134

Always `00 00 00 00`.

#### Offsets 138 and 139

Always `00`.

#### Offsets 160 through 180

Known values:

The following `RACE`s have 0.0 for all values: `ModelARace`, `ModelSRace`, `CritterRace`, `AutopilotRace`, `FloaterARace`, `SecurityCameraRace`, `BallisticTurretRace`, `LaserTurretRace`, `MannequinRace`, `MiniBotARace`, `FlyerARace`, `SwimmerARace`, `MantaARace`, `LarvaARace`, `ParasiteARace`

All other `RACE`s have various values here that I'm too tired to document right now ;)

#### Offsets 184 / 188

Known values:

- `00 00 00 00`
- `01 00 00 00`
- `02 00 00 00`
- `03 00 00 00`

These are probably integers or flags.

#### Struct at offset 192

Comment in `wbDefinitionsSF1` mentions this is "Same as `NPC_` -> `ONA2` - Unknown 7.  No new findings on my end aside from the fact that one of the floats (at offset 209) is always 0.0.

## Skeleton Data

The "Unknown" `FLLD` is always set to `Unknown 0`

## Movement Data Overrides

The only `RACE` with anything defined here is `LarvaARace`.  A couple of the "unknown" values in there are approximately pi; all others are at 1.0 or below.

## Chargen and Skintones

The "unknown" `NNAM` is set for `HumanCrowdRace`; male has `AB AB AB AB 00 00 00 00 00 00 00 00` while female has `AB AB AB AB AB AB AB AB AB AB AB AB`.  I wonder if this has anything to do with crowd NPCs being clones of one another (once you remove the skinsuits they wear as inventory items)?

</p>
</details> 