### PR TITLE
Fo4 - Missing Condition Form Type

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -7707,6 +7707,7 @@ begin
    100, 'Scroll',
    101, 'ColorForm',
    102, 'Reverb Parameters',
+   109, 'Component',
    116, 'Terminal'
   ]);
 


### PR DESCRIPTION
Reported on discord - Missing Form Type (Conditions)