### PR TITLE
Update Navmesh/NAVI definitions/decoding

### DIFF
--- a/Build/Edit Scripts/Skyrim - Check edge links in navmeshes.pas
+++ b/Build/Edit Scripts/Skyrim - Check edge links in navmeshes.pas
@@ -87,7 +87,7 @@ begin
       end
       else begin
         EdgeLink := ElementByIndex(EdgeLinks, EdgeValue);
-        if (FormID(LinksTo(ElementByName(EdgeLink, 'Mesh'))) = FormID(navm2)) and (GetElementNativeValues(EdgeLink, 'Triangle') = tri2) then begin
+        if Equals(MasterOrSelf(LinksTo(ElementByName(EdgeLink, 'Navmesh'))), MasterOrSelf(navm2)) and (GetElementNativeValues(EdgeLink, 'Triangle') = tri2) then begin
           Result := True;
           Exit;
         end;
@@ -139,7 +139,7 @@ begin
         else begin
           Inc(EdgeLinkFound);
           EdgeLink := ElementByIndex(EdgeLinks, EdgeValue);
-          if not CheckEdgeLink(WinningOverride(LinksTo(ElementByName(EdgeLink, 'Mesh'))), e, GetElementNativeValues(EdgeLink, 'Triangle'), i) then begin
+          if not CheckEdgeLink(WinningOverride(LinksTo(ElementByName(EdgeLink, 'Navmesh'))), e, GetElementNativeValues(EdgeLink, 'Triangle'), i) then begin
             AddMessage(Format('via %s link %d', [arEdge[j], EdgeValue]));
             Inc(warnings);
           end;

--- a/Build/Edit Scripts/Skyrim - Clean edge links in navmeshes.pas
+++ b/Build/Edit Scripts/Skyrim - Clean edge links in navmeshes.pas
@@ -34,8 +34,8 @@ begin
     if elT = GetElementNativeValues(EdgeLink, 'Triangle') then begin
       //AddMessage(Format('%d = %d', [elT, GetElementNativeValues(EdgeLink, 'Triangle')]));
       //AddMessage(elM);
-      //AddMessage(GetElementEditValues(EdgeLink, 'Mesh'));
-      if CompareStr(elM, GetElementEditValues(EdgeLink, 'Mesh')) = 0 then begin
+      //AddMessage(GetElementEditValues(EdgeLink, 'Navmesh'));
+      if CompareStr(elM, GetElementEditValues(EdgeLink, 'Navmesh')) = 0 then begin
         //AddMessage(Format('found %d', [k]));
         Result := k;
         Exit;
@@ -100,9 +100,9 @@ begin
   SetNativeValue(havePath, GetNativeValue(swapPath));
   SetNativeValue(swapPath, saveValue);
 
-  havePath := ElementByPath(haveLink, 'Mesh');
+  havePath := ElementByPath(haveLink, 'Navmesh');
   saveString := GetEditValue(havePath);
-  swapPath := ElementByPath(swapLink, 'Mesh');
+  swapPath := ElementByPath(swapLink, 'Navmesh');
   SetEditValue(havePath, GetEditValue(swapPath));
   SetEditValue(swapPath, saveString);
 
@@ -262,7 +262,7 @@ begin
         else begin
           // search old Edge Links for possible match...
           haveLink := ElementByIndex(newLinks, newLinkIndex);
-          saveString := GetElementEditValues(haveLink, 'Mesh');
+          saveString := GetElementEditValues(haveLink, 'Navmesh');
           saveValue := GetElementNativeValues(haveLink, 'Triangle');
           oldLinkIndex := FindEdgeLink(oldLinks, saveString, saveValue);
           if oldLinkIndex < 0 then begin
@@ -310,7 +310,7 @@ begin
       end
       else if oldLinkIndex >= 0 then begin
         haveLink := ElementByIndex(oldLinks, oldLinkIndex);
-        saveString := GetElementEditValues(haveLink, 'Mesh');
+        saveString := GetElementEditValues(haveLink, 'Navmesh');
         saveValue := GetElementNativeValues(haveLink, 'Triangle');
         AddMessage(Format('Want match for triangle %d in %s', [saveValue, saveString]));
         AddMessage(Format('via old %s link %d', [arEdge[j], oldLinkIndex]));

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8216,7 +8216,7 @@ Can't properly represent that with current record definition methods.
         wbUnion('Island', wbNAVIIslandDataDecider, [
           wbNull,
           wbNAVIslandData
-        ]),
+        ]).IncludeFlag(dfCollapsed),
         wbStruct('PathingCell', [
           wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingCell'),
           wbFormIDCk('Parent Worldspace', [WRLD, NULL]),

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8013,7 +8013,7 @@ begin
         wbArray('Edge Links',
           wbStruct('Edge Link', [
             wbByteArray('Unknown', 4),
-            wbFormIDCk('Mesh', [NAVM]),
+            wbFormIDCk('Navmesh', [NAVM]),
             wbInteger('Triangle', itS16)
           ])
         , -1).IncludeFlag(dfNotAlignable),
@@ -8114,16 +8114,20 @@ Can't properly represent that with current record definition methods.
         , -1).IncludeFlag(dfNotAlignable),
         wbArray('Edge Links',
           wbStruct('Edge Link', [
-            wbByteArray('Unknown', 4, cpIgnore),
-            wbFormIDCk('Mesh', [NAVM], False, cpIgnore),
+            wbInteger('Type', itU32, wbEnum([], [
+              0, 'Normal',
+              $01, 'Dropdown Top',
+              $02, 'Dropdown Bottom'
+            ]), cpIgnore),
+            wbFormIDCk('Navmesh', [NAVM], False, cpIgnore),
             wbInteger('Triangle', itS16, nil, cpIgnore)
           ], cpIgnore)
         , -1, cpIgnore).IncludeFlag(dfNotAlignable),
         wbArrayS('Door Triangles',
           wbStructSK([0, 2], 'Door Triangle', [
             wbInteger('Triangle before door', itS16).SetLinksToCallback(wbTriangleLinksTo),
-            wbInteger('Door Type', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
-            wbFormIDCk('Door', [REFR])
+            wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
+            wbFormIDCk('Door Ref', [REFR])
           ])
         , -1),
         wbArray('Cover Triangles',
@@ -8145,7 +8149,7 @@ Can't properly represent that with current record definition methods.
         ).IncludeFlag(dfNotAlignable) // There are NavMeshGridSize^2 arrays to load
       ]);
 
-  wbRecord(NAVM, 'Navigation Mesh',
+  wbRecord(NAVM, 'Navmesh',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
       {0x00040000} 18, 'Compressed',
       {0x04000000} 26, 'AutoGen',
@@ -8163,8 +8167,8 @@ Can't properly represent that with current record definition methods.
     wbNAVIslandData :=
       wbStruct('Island Data', [
         wbByteArray('Unknown', 24),
-        wbArray('Triangles', wbByteArray('Triangle', 6), -1),
-        wbArray('Vertices', wbByteArray('Vertex', 12), -1)
+        wbArray('Triangles', wbByteArray('Triangle', 6), -1).IncludeFlag(dfCollapsed),
+        wbArray('Vertices', wbByteArray('Vertex', 12), -1).IncludeFlag(dfCollapsed)
       ])
   else
     wbNAVIslandData :=
@@ -8177,33 +8181,37 @@ Can't properly represent that with current record definition methods.
         wbFloat('Max Z'),
         wbArray('Triangles',
           wbStruct('Triangle', [
-            wbArray('Vertices', wbInteger('Vertex', itS16), 3).IncludeFlag(dfNotAlignable)
-          ])
-        , -1).IncludeFlag(dfNotAlignable),
+            wbArray('Vertices', wbInteger('Vertex', itS16), 3).IncludeFlag(dfNotAlignable).IncludeFlag(dfCollapsed)
+          ]).IncludeFlag(dfCollapsed)
+        , -1).IncludeFlag(dfNotAlignable).IncludeFlag(dfCollapsed),
         wbArray('Vertices', wbStruct('Vertex', [
           wbFloat('X'),
           wbFloat('Y'),
           wbFloat('Z')
-        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable)
+        ]).SetToStr(wbVec3ToStr).IncludeFlag(dfCollapsed, wbCollapseVec3), -1).IncludeFlag(dfNotAlignable).IncludeFlag(dfCollapsed)
       ]);
 
-  wbRecord(NAVI, 'Navigation Mesh Info Map', [
+  wbRecord(NAVI, 'Navmesh Info Map', [
     wbEDID,
     wbInteger(NVER, 'Version', itU32),
-    wbRArray('Navigation Map Infos',
-      wbStruct(NVMI, 'Navigation Map Info', [
-        wbFormIDCk('Navigation Mesh', [NAVM]),
-        wbByteArray('Unknown', 4),
+    wbRArrayS('Navmesh Infos',
+      wbStructSK(NVMI,[0], 'Navmesh Info', [
+        wbFormIDCk('Navmesh', [NAVM]),
+        wbInteger('Category', itU32, wbEnum([], [
+          0, 'Is Edited and Not Island',
+          $20, 'Is Edited and Is Island',
+          $40, 'Not Edited and Not Island'
+        ])),
         wbFloat('X'),
         wbFloat('Y'),
         wbFloat('Z'),
-        wbInteger('Preferred Merges Flag', itU32),
-        wbArray('Merged To', wbFormIDCk('Mesh', [NAVM]), -1),
-        wbArray('Preferred Merges', wbFormIDCk('Mesh', [NAVM]), -1),
-        wbArray('Linked Doors', wbStruct('Door', [
-          wbByteArray('Unknown', 4),
+        wbByteArray('Preferred Merges Flag', 4),
+        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed),
+        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed),
+        wbArrayS('Door Links', wbStructSK([1],'Door', [
+          wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
           wbFormIDCk('Door Ref', [REFR])
-        ]), -1),
+        ]), -1).IncludeFlag(dfCollapsed),
         wbInteger('Is Island', itU8, wbEnum(['False', 'True'])),
         wbUnion('Island', wbNAVIIslandDataDecider, [
           wbNull,
@@ -8218,18 +8226,18 @@ Can't properly represent that with current record definition methods.
               wbInteger('Grid X', itS16)
             ]),
             wbFormIDCk('Parent Cell', [CELL])
-          ])
-        ])
-      ])
-    ),
+          ]).IncludeFlag(dfCollapsed)
+        ]).IncludeFlag(dfCollapsed)
+      ]).IncludeFlag(dfCollapsed)
+    ).IncludeFlag(dfCollapsed),
     wbStruct(NVPP, 'Preferred Pathing', [
-      wbArray('NavMeshes', wbArray('Set', wbFormIDCk('', [NAVM]), -1), -1),
-      wbArray('NavMesh Tree?', wbStruct('', [
-        wbFormIDCk('NavMesh', [NAVM]),
+      wbArray('Perferred Paths', wbArray('Path', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed), -1).IncludeFlag(dfCollapsed),
+      wbArray('Path Index?', wbStruct('', [
+        wbFormIDCk('Navmesh', [NAVM]),
         wbInteger('Index/Node', itU32)
-      ]), -1)
-    ]),
-    wbArray(NVSI, 'Unknown', wbFormIDCk('Navigation Mesh', [NAVM]))
+      ]).IncludeFlag(dfCollapsed), -1).IncludeFlag(dfCollapsed)
+    ]).IncludeFlag(dfCollapsed),
+    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM])).IncludeFlag(dfCollapsed)
   ]);
 
 end;
@@ -12343,8 +12351,8 @@ begin
     wbFormIDCk(XEZN, 'Encounter Zone', [ECZN]),
 
     {--- Generated Data ---}
-    wbStruct(XNDP, 'Navigation Door Link', [
-      wbFormIDCk('Navigation Mesh', [NAVM]),
+    wbStruct(XNDP, 'Navmesh Door Link', [
+      wbFormIDCk('Navmeshesh', [NAVM]),
       wbInteger('Teleport Marker Triangle', itS16, wbREFRNavmeshTriangleToStr, wbStringToInt),
       wbByteArray('Unused', 2, cpIgnore)
     ]),

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8224,7 +8224,7 @@ Can't properly represent that with current record definition methods.
             wbStruct('Coordinates', [
               wbInteger('Grid Y', itS16),
               wbInteger('Grid X', itS16)
-            ]),
+            ]).IncludeFlag(dfCollapsed),
             wbFormIDCk('Parent Cell', [CELL])
           ]).IncludeFlag(dfCollapsed)
         ]).IncludeFlag(dfCollapsed)

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8115,9 +8115,10 @@ Can't properly represent that with current record definition methods.
         wbArray('Edge Links',
           wbStruct('Edge Link', [
             wbInteger('Type', itU32, wbEnum([], [
-              0, 'Normal',
-              $01, 'Dropdown Top',
-              $02, 'Dropdown Bottom'
+              0, 'Portal',
+              $01, 'Ledge Up',
+              $02, 'Ledge Down',
+              $03, 'Enable/Disable Portal'
             ]), cpIgnore),
             wbFormIDCk('Navmesh', [NAVM], False, cpIgnore),
             wbInteger('Triangle', itS16, nil, cpIgnore)

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8012,7 +8012,12 @@ begin
         wbArray('Triangles', wbByteArray('Triangle', 16), -1).IncludeFlag(dfNotAlignable),
         wbArray('Edge Links',
           wbStruct('Edge Link', [
-            wbByteArray('Unknown', 4),
+            wbInteger('Type', itU32, wbEnum([], [
+              0, 'Portal',
+              $01, 'Ledge Up',
+              $02, 'Ledge Down',
+              $03, 'Enable/Disable Portal'
+            ]), cpIgnore),
             wbFormIDCk('Navmesh', [NAVM]),
             wbInteger('Triangle', itS16)
           ])

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8158,9 +8158,9 @@ Can't properly represent that with current record definition methods.
     ]), [18]), [
     wbEDID,
     wbNVNM,
-    wbUnknown(ONAM),
-    wbUnknown(PNAM),
-    wbUnknown(NNAM)
+    wbArray(ONAM,'Base Objects', wbFormIDCk('Base Object', [CONT, FURN, TREE, STAT, NULL])),
+    wbArray(PNAM, 'Preferred Connectors', wbInteger('Vertex', itU16)),
+    wbArray(NNAM, 'Non Connectors', wbInteger('Vertex', itU16))
   ], False, wbNAVMAddInfo);
 
 

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -532,7 +532,7 @@ begin
           Exit;
 
         MainRecord := nil;
-        if not Supports(EdgeLink.ElementLinksTo['Mesh'], IwbMainRecord, MainRecord) then
+        if not Supports(EdgeLink.ElementLinksTo['Navmesh'], IwbMainRecord, MainRecord) then
           Exit;
 
         aInt := EdgeLink.ElementNativeValues['Triangle'];
@@ -566,7 +566,7 @@ begin
         EdgeLink := EdgeLinks.Elements[aInt] as IwbContainerElementRef;
 
         MainRecord := nil;
-        if not Supports(EdgeLink.ElementLinksTo['Mesh'], IwbMainRecord, MainRecord) then
+        if not Supports(EdgeLink.ElementLinksTo['Navmesh'], IwbMainRecord, MainRecord) then
           Exit;
 
         if Assigned(MainRecord) then
@@ -627,7 +627,7 @@ begin
     EdgeLink := EdgeLinks.Elements[aInt] as IwbContainerElementRef;
 
     MainRecord := nil;
-    if not Supports(EdgeLink.ElementLinksTo['Mesh'], IwbMainRecord, MainRecord) then
+    if not Supports(EdgeLink.ElementLinksTo['Navmesh'], IwbMainRecord, MainRecord) then
       Exit;
 
     aInt := EdgeLink.ElementNativeValues['Triangle'];

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -12352,7 +12352,7 @@ begin
 
     {--- Generated Data ---}
     wbStruct(XNDP, 'Navmesh Door Link', [
-      wbFormIDCk('Navmeshesh', [NAVM]),
+      wbFormIDCk('Navmesh', [NAVM]),
       wbInteger('Teleport Marker Triangle', itS16, wbREFRNavmeshTriangleToStr, wbStringToInt),
       wbByteArray('Unused', 2, cpIgnore)
     ]),

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8151,6 +8151,7 @@ Can't properly represent that with current record definition methods.
 
   wbRecord(NAVM, 'Navmesh',
     wbFlags(wbRecordFlagsFlags, wbFlagsList([
+      {0x00000800} 11, 'Initially Disabled',
       {0x00040000} 18, 'Compressed',
       {0x04000000} 26, 'AutoGen',
       {0x80000000} 31, 'NavmeshGenCell'

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8198,9 +8198,14 @@ Can't properly represent that with current record definition methods.
       wbStructSK(NVMI,[0], 'Navmesh Info', [
         wbFormIDCk('Navmesh', [NAVM]),
         wbInteger('Category', itU32, wbEnum([], [
-          0, 'Is Edited and Not Island',
-          $20, 'Is Edited and Is Island',
-          $40, 'Not Edited and Not Island'
+          0, 'Is Edited',
+          //All navmesh records, that are not islands and are directly edited by the given plugin, receive an NVMI entry where this Integer is 0
+          $20, 'Is Island',
+          //All navmesh records, that are islands and are present in cells where the given plugin makes navmesh edits, receive an NVMI entry where this Integer is 20.
+          //Whether the given plugin actually contains these islands navmeshes or not, does not matter.
+          $40, 'Not Edited'
+          //NVMI entries are generated for navmeshes that are not edited by the given plugin, but their NVMI entry in one of the given plugins' masters contains wrong data or is nonexistent
+          //Also NVMI entries are generated for navmeshes on which a RoadMarker sits in all plugins as "ITM" entries.  Probably used for computing the precomputed paths
         ])),
         wbFloat('X'),
         wbFloat('Y'),

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -8230,11 +8230,11 @@ Can't properly represent that with current record definition methods.
         ]).IncludeFlag(dfCollapsed)
       ]).IncludeFlag(dfCollapsed)
     ).IncludeFlag(dfCollapsed),
-    wbStruct(NVPP, 'Preferred Pathing', [
-      wbArray('Perferred Paths', wbArray('Path', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed), -1).IncludeFlag(dfCollapsed),
-      wbArray('Path Index?', wbStruct('', [
+    wbStruct(NVPP, 'Precomputed Pathing', [
+      wbArray('Precomputed Paths', wbArray('Path', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed), -1).IncludeFlag(dfCollapsed),
+      wbArrayS('Road Marker Index', wbStructSK([1],'Road Marker', [
         wbFormIDCk('Navmesh', [NAVM]),
-        wbInteger('Index/Node', itU32)
+        wbInteger('Index', itU32)
       ]).IncludeFlag(dfCollapsed), -1).IncludeFlag(dfCollapsed)
     ]).IncludeFlag(dfCollapsed),
     wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM])).IncludeFlag(dfCollapsed)


### PR DESCRIPTION
Changed "Navigation Mesh" & related to "Navmesh" to match the CK

Decoded PathingDoor on NAVI \ NVMI \ Door links

Decoded NAVI \ NVMI Categories  Decoded NAVM \ Edge Links \  Type

Also added sorting on some arrays on NAVI that are confirmed sort-able.  Still testing the ones under NVPP

As well as added includeFlag(dfCollapsed) on virtually all of the collapseable nodes which has shown a rather significant performance improvement when looking at/comparing/editing the NAVI record in xEdit.  And/or comparing multiple NAVIs across several plugins at once.

Updated other names to better reflect the data they actually represent.