### PR TITLE
Update Landscape

### DIFF
--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -12812,7 +12812,6 @@ begin
       wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
       wbLandscapeLayers(wbSimpleRecords),
-      wbArray(VTEX, 'Textures', wbFormIDCk('Texture', [LTEX, NULL])),
       wbRArray('Hi-Res Heightfield Data', wbByteArray(MPCD, 'Data'))
     ]);
 

--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -12838,7 +12838,6 @@ begin
       wbVertexHeightMap,
       wbVertexColumns(VCLR, 'Vertex Colours'),
       wbLandscapeLayers(wbSimpleRecords),
-      wbArray(VTEX, 'Textures', wbFormIDCk('Texture', [LTEX, NULL])),
       wbRArray('Hi-Res Heightfield Data', wbByteArray(MPCD, 'Data'))
     ]);
 

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -10331,7 +10331,6 @@ begin
       wbByteArray(VHGT, 'Vertex Height Map'),
       wbByteArray(VCLR, 'Vertex Colours'),
       wbLandscapeLayers(wbSimpleRecords),
-      wbArray(VTEX, 'Textures', wbFormIDCk('Texture', [LTEX, NULL])),
       wbRArray('Unknown', wbUnknown(MPCD)) // Handling is present in the EXE, not seen in the base game
     ]);
 

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -10319,7 +10319,7 @@ begin
         {0x00000002} 'Has Vertex Colours',
         {0x00000004} 'Has Layers',
         {0x00000008} 'Unknown 4',
-        {0x00000010} 'Unknown 5', // added by the CK to all land records when you run World > World Test > Recalc Normals
+        {0x00000010} 'Auto-Calc Normals', // Present on every LAND after running Recalc Normals in the CK.
         {0x00000020} '',
         {0x00000040} '',
         {0x00000080} '',
@@ -10345,7 +10345,7 @@ begin
         'Has Vertex Colours',
         'Has Layers',
         'Unknown 4',
-        'Unknown 5',
+        'Auto-Calc Normals',
         '',
         '',
         '',
@@ -10357,7 +10357,6 @@ begin
       wbVertexHeightMap,
       wbVertexColumns(VCLR, 'Vertex Colours'),
       wbLandscapeLayers(wbSimpleRecords),
-      wbArray(VTEX, 'Textures', wbFormIDCk('Texture', [LTEX, NULL])),
       wbRArray('Unknown', wbUnknown(MPCD))
     ]);
 

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -10319,7 +10319,7 @@ begin
         {0x00000002} 'Has Vertex Colours',
         {0x00000004} 'Has Layers',
         {0x00000008} 'Unknown 4',
-        {0x00000010} 'Unknown 5',
+        {0x00000010} 'Unknown 5', // added by the CK to all land records when you run World > World Test > Recalc Normals
         {0x00000020} '',
         {0x00000040} '',
         {0x00000080} '',


### PR DESCRIPTION
Eck confirmed that VTEX does not exist at all in Skyrim or Fallout 4.  Testing in both CKs, on save it just deletes VTEX in all cases.