### PR TITLE
Miscellaneous scripting changes

### DIFF
--- a/Core/wbHelpers.pas
+++ b/Core/wbHelpers.pas
@@ -366,7 +366,7 @@ begin
     StrictDelimiter := True;
     DelimitedText := aSignatures;
     for i := 0 to Pred(Count) do begin
-      s := AnsiString(Strings[i]);
+      s := Trim(AnsiString(Strings[i]));
       if Length(s) >= SizeOf(TwbSignature) then begin
         SetLength(Result, Succ(Length(Result)));
         System.Move(s[1], Result[Pred(Length(Result))][0], SizeOf(TwbSignature));

--- a/xEdit/JvI/xejviScriptAdapter.pas
+++ b/xEdit/JvI/xejviScriptAdapter.pas
@@ -1441,13 +1441,13 @@ begin
   end;
 end;
 
-procedure IwbFile_GetLoadOrder(var Value: Variant; Args: TJvInterpreterArgs);
+procedure IwbFile_GetLoadOrderFileID(var Value: Variant; Args: TJvInterpreterArgs);
 var
   _File: IwbFile;
 begin
   Value := -1;
   if Supports(IInterface(Args.Values[0]), IwbFile, _File) then
-    Value := _File.LoadOrder;
+    Value := _File.LoadOrderFileID.ToString;
 end;
 
 procedure IwbFile_GetNewFormID(var Value: Variant; Args: TJvInterpreterArgs);
@@ -2194,7 +2194,7 @@ begin
 
     { IwbFile }
     AddFunction(cUnit, 'GetFileName', IwbFile_GetFileName, 1, [varEmpty], varEmpty);
-    AddFunction(cUnit, 'GetLoadOrder', IwbFile_GetLoadOrder, 1, [varEmpty], varEmpty);
+    AddFunction(cUnit, 'GetLoadOrderFileID', IwbFile_GetLoadOrderFileID, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'GetNewFormID', IwbFile_GetNewFormID, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'GetIsESM', IwbFile_GetIsESM, 1, [varEmpty], varEmpty);
     AddFunction(cUnit, 'SetIsESM', IwbFile_SetIsESM, 2, [varEmpty, varBoolean], varEmpty);

--- a/xEdit/JvI/xejviScriptHost.pas
+++ b/xEdit/JvI/xejviScriptHost.pas
@@ -17,6 +17,7 @@ implementation
 uses
   Classes,
   SysUtils,
+  StrUtils,
   System.Generics.Collections,
   Variants,
   Forms,
@@ -70,8 +71,6 @@ var
   MainRecord          : IwbMainRecord;
   Container           : IwbContainerElementRef;
   _File               : IwbFile;
-  Node                : PVirtualNode;
-  NodeData            : PNavNodeData;
   NodeDatas           : TDynViewNodeDatas;
   ConflictThis        : TConflictThis;
   ConflictAll         : TConflictAll;
@@ -182,10 +181,11 @@ begin
     end else
       JvInterpreterError(ieDirectInvalidArgument, 0); // or  ieNotEnoughParams, ieIncompatibleTypes or others.
   end
-  else if SameText(Identifier, 'FileByLoadOrder') then begin
+  else if SameText(Identifier, 'FileByLoadOrderFileID') then begin
     if (Args.Count = 1) and VarIsNumeric(Args.Values[0]) and (Args.Values[0] < Length(Files)) then begin
+      var aLoadOrderFileID := TwbFileID.Create(Integer(Args.Values[0]));
       for i := Low(Files) to High(Files) do
-        if Files[i].LoadOrder = Integer(Args.Values[0]) then begin
+        if Files[i].LoadOrderFileID = aLoadOrderFileID then begin
           Value := Files[i];
           Break;
         end;
@@ -257,9 +257,9 @@ begin
   else if SameText(Identifier, 'RemoveNode') and (Args.Count = 1) then begin
     Value := False;
     if Supports(IInterface(Args.Values[0]), IwbElement, Element) then begin
-      Node := FindNodeForElement(Element);
+      var Node: PVirtualNode := FindNodeForElement(Element);
       if Assigned(Node) then begin
-        NodeData := vstNav.GetNodeData(Node);
+        var NodeData: PNavNodeData := vstNav.GetNodeData(Node);
         if Supports(Element, IwbMainRecord, MainRecord) then begin
           CheckHistoryRemove(BackHistory, MainRecord);
           CheckHistoryRemove(ForwardHistory, MainRecord);
@@ -297,9 +297,9 @@ begin
   end
   else if SameText(Identifier, 'ConflictThisForNode') and (Args.Count = 1) then begin
     if Supports(IInterface(Args.Values[0]), IwbElement, Element) then begin
-      Node := FindNodeForElement(Element);
+      var Node: PVirtualNode := FindNodeForElement(Element);
       if Assigned(Node) then begin
-        NodeData := vstNav.GetNodeData(Node);
+        var NodeData: PNavNodeData := vstNav.GetNodeData(Node);
         Value := NodeData.ConflictThis;
       end;
       Done := True;
@@ -308,9 +308,9 @@ begin
   end
   else if SameText(Identifier, 'ConflictAllForNode') and (Args.Count = 1) then begin
     if Supports(IInterface(Args.Values[0]), IwbElement, Element) then begin
-      Node := FindNodeForElement(Element);
+      var Node: PVirtualNode := FindNodeForElement(Element);
       if Assigned(Node) then begin
-        NodeData := vstNav.GetNodeData(Node);
+        var NodeData: PNavNodeData := vstNav.GetNodeData(Node);
         Value := NodeData.ConflictAll;
       end;
       Done := True;

--- a/xEdit/JvI/xejviScriptHost.pas
+++ b/xEdit/JvI/xejviScriptHost.pas
@@ -442,6 +442,28 @@ begin
   else if SameText(Identifier, 'dfFloatDecimalDigits') and (Args.Count = 0) then begin
     Value := dfFloatDecimalDigits;
     Done := True;
+  end
+  else if SameText(Identifier, 'wbSelectedFilesToFileNames') then begin
+    if (Args.Count = 1) then
+    begin
+      var Nodes: TNodeArray := vstNav.GetSortedSelection(True);
+
+      for i := Low(Nodes) to High(Nodes) do begin
+        var NodeData: PNavNodeData := vstNav.GetNodeData(Nodes[i]);
+        if not Assigned(NodeData) then
+          Continue;
+        Element := NodeData.Element;
+        if Supports(Element, IwbFile, _File) then
+          if TStrings(V2O(Args.Values[0])).IndexOf(_File.FileName) = -1 then
+            TStrings(V2O(Args.Values[0])).Add(_File.FileName)
+        else if Supports(Element, IwbMainRecord, MainRecord) then
+          if TStrings(V2O(Args.Values[0])).IndexOf(MainRecord._File.FileName) = -1 then
+            TStrings(V2O(Args.Values[0])).Add(MainRecord._File.FileName);
+      end;
+
+      Done := True;
+    end else
+      JvInterpreterError(ieDirectInvalidArgument, 0); // or  ieNotEnoughParams, ieIncompatibleTypes or others.
   end;
 end;
 


### PR DESCRIPTION
- Replaced `FileByLoadOrder` with `FileByLoadOrderFileID` (breaking change to remove function broken by ESLs)
- Replaced `GetLoadOrder` with `GetLoadOrderFileID` (breaking change to remove function broken by ESLs)
- Added `wbSelectedFilesToFileNames` function (requested)
- Removed unnecessary whitespace from user list items passed to `wbFindREFRsByBase` and `wbGetSiblingRecords`
