### PR TITLE
Fixed small spelling error

### DIFF
--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -6724,7 +6724,7 @@ begin
       wbTimeInterpolators(NAM1, 'Ramp Down'),
       wbTimeInterpolators(NAM2, 'Down Start')
     ], []),
-    wbRStruct('Depht of Field', [
+    wbRStruct('Depth of Field', [
       wbTimeInterpolators(WNAM, 'Strength'),
       wbTimeInterpolators(XNAM, 'Distance'),
       wbTimeInterpolators(YNAM, 'Range')


### PR DESCRIPTION
Depht > Depth
I don't use github or program much so apologies if this is submitted incorrectly but I noticed a spelling error while using xEdit today so I figured I'd create a pull request for it. Github search only showed it in this file so I figure its probably the one causing it (and not some translation file somewhere?).