### PR TITLE
Select FalloutNV_Epic folder for the EGS version

### DIFF
--- a/xEdit/xeInit.pas
+++ b/xEdit/xeInit.pas
@@ -443,6 +443,10 @@ begin
     else
       wbMyGamesTheGamePath := xeMyProfileName + 'My Games\' + wbGameName2 + '\';
     end;
+
+    if (wbGameMode in [gmFNV]) and wbDataPath.Contains('FalloutNewVegas\Fallout New Vegas ') then begin
+        wbMyGamesTheGamePath := xeMyProfileName + 'My Games\FalloutNV_Epic\';
+    end;
   end;
 
   if not wbFindCmdLineParam('I', wbTheGameIniFileName) then begin

--- a/xEdit/xeInit.pas
+++ b/xEdit/xeInit.pas
@@ -344,10 +344,12 @@ const
   sSureAIRegKey           = '\Software\SureAI\';
 
 var
-  s, regPath, regKey, client: string;
+  s, regPath, regKey, client, gamePath: string;
+  isEpicNV : Boolean;
   IniFile : TMemIniFile;
 begin
   wbModGroupFileName := wbProgramPath + wbAppName + wbToolName + '.modgroups';
+  isEpicNV := false;
 
   if not wbFindCmdLineParam('S', wbScriptsPath) then
     wbScriptsPath := wbProgramPath + 'Edit Scripts\';
@@ -403,10 +405,10 @@ begin
       gmFO76, gmSF1:     regKey := 'InstallLocation';
       end;
 
-      wbDataPath := ReadString(regKey);
-      wbDataPath := StringReplace(wbDataPath, '"', '', [rfReplaceAll]);
+      gamePath := ReadString(regKey);
+      gamePath := StringReplace(gamePath, '"', '', [rfReplaceAll]);
 
-      if (wbDataPath = '') then begin
+      if (gamePath = '') then begin
         s := Format('Fatal: Could not determine %s installation path, no "%s" registry key', [wbGameName2, regKey]);
         ShowMessage(Format('%s'#13#10'This can happen after %s updates, run the game''s launcher to restore registry settings', [s, client]));
         wbDontSave := True;
@@ -414,10 +416,10 @@ begin
     finally
       Free;
     end;
-    if wbDataPath <> '' then
-      wbDataPath := IncludeTrailingPathDelimiter(wbDataPath) + DataName[wbGameMode = gmTES3] + '\';
+    if gamePath <> '' then
+      wbDataPath := IncludeTrailingPathDelimiter(gamePath) + DataName[wbGameMode = gmTES3] + '\';
   end else
-    wbDataPath := IncludeTrailingPathDelimiter(wbDataPath);
+    wbDataPath := IncludeTrailingPathDelimiter(gamePath);
 
   wbOutputPath := wbDataPath;
   if wbFindCmdLineParam('O', s) and (Length(s) > 0) then
@@ -444,8 +446,9 @@ begin
       wbMyGamesTheGamePath := xeMyProfileName + 'My Games\' + wbGameName2 + '\';
     end;
 
-    if (wbGameMode in [gmFNV]) and wbDataPath.Contains('FalloutNewVegas\Fallout New Vegas ') then begin
+    if (wbGameMode in [gmFNV]) and FileExists(IncludeTrailingPathDelimiter(gamePath) + 'EOSSDK-Win32-Shipping.dll') then begin
         wbMyGamesTheGamePath := xeMyProfileName + 'My Games\FalloutNV_Epic\';
+        isEpicNV := true;
     end;
   end;
 
@@ -508,6 +511,8 @@ begin
 
       if wbGameMode = gmFO76 then
         wbPluginsFileName := wbPluginsFileName + wbGameName + '\Plugins.txt'
+      else if (wbGameMode = gmFNV) and isEpicNV then
+        wbPluginsFileName := wbPluginsFileName + wbGameName + '_Epic' + '\Plugins.txt'
       else
         wbPluginsFileName := wbPluginsFileName + wbGameName2 + '\Plugins.txt';
     end;


### PR DESCRIPTION
Allows FNVEdit to be fully compatible with the EGS release of Fallout New Vegas after using the [Patcher](https://www.nexusmods.com/newvegas/mods/81281), which now creates a proper registry key.

~~Checking for "FalloutNewVegas\Fallout New Vegas " substring is safe as it's fixed - Epic does not allow you to change the game directory name, has no spaces, and the actual root folder is always a subfolder with language in it - "Fallout New Vegas English", "Fallout New Vegas Italian", etc.~~

Detection is now a bit more sane - we now check for `EOSSDK-Win32-Shipping.dll` in the root folder. Thanks, JonathanOstrus!