### PR TITLE
Updates for FO76

### DIFF
--- a/Core/wbDefinitionsCommon.pas
+++ b/Core/wbDefinitionsCommon.pas
@@ -621,6 +621,7 @@ begin
     Sig2Int(ASSU), 'Assault Actor Event',
     Sig2Int(BRIB), 'Bribe',
     Sig2Int(CAST), 'Cast Magic Event',
+    Sig2Int(CBGN), 'Caravan Begin Event',
     Sig2Int(CHRR), 'Change Relationship Rank',
     Sig2Int(CLOC), 'Change Location Event',
     Sig2Int(CLRL), 'Clear Location Event',

--- a/Core/wbDefinitionsSignatures.pas
+++ b/Core/wbDefinitionsSignatures.pas
@@ -226,6 +226,7 @@ const
   CAMS : TwbSignature = 'CAMS';
   CARD : TwbSignature = 'CARD';
   CAST : TwbSignature = 'CAST';
+  CBGN : TwbSignature = 'CBGN'; { New to Fallout 76 }
   CCRD : TwbSignature = 'CCRD';
   CDCK : TwbSignature = 'CDCK';
   CDIX : TwbSignature = 'CDIX'; { New to Fallout 4 }


### PR DESCRIPTION
Added new event CBGN: Caravan Begin Event
Added FURN and GMRW to the quest stage decider
Fixed IsPreviousMeleeAttackEvent condition function. Added GetLanguage, IsNextClipLastShot, WornInOrOutOfPowerArmorHasKeyword, IsPlayerInBestBuildCamp, GetIsInExpedition, IsCaravanAvailable, and IsUsingAltCurveTable condition functions

Added IsNextClipLastShot entry point.
L1 is Location1, L2 is Location2, L3 is Location3
Modify NVNM to check for length and if it's empty it's a marker. Added Item Rarity category for keywords.
Added Weight Mult armor property

Added WeightMult, AmmoConsumption, Overheating, OverheatRateUp, and OverheatRateDown weapon properties

Added Quest to ARMO
EPF2 can be a curve table if the type is Float
Added Caravan quest type.