### PR TITLE
SF1: Improved CK2 Interoperability

### DIFF
--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -21654,13 +21654,14 @@ end;
 
   wbNexusModsUrl := 'https://www.nexusmods.com/starfield/mods/239';
 
-  SetLength(wbOfficialDLC, 3);
+  SetLength(wbOfficialDLC, 7);
   wbOfficialDLC[0] := 'Constellation.esm';
   wbOfficialDLC[1] := 'OldMars.esm';
   wbOfficialDLC[2] := 'BlueprintShips-Starfield.esm';
-//  wbOfficialDLC[3] := 'SFBGS006.esm';
-//  wbOfficialDLC[4] := 'SFBGS008.esm';
-//  wbOfficialDLC[5] := 'SFBGS007.esm';
+  wbOfficialDLC[3] := 'SFBGS007.esm';
+  wbOfficialDLC[4] := 'SFBGS008.esm';
+  wbOfficialDLC[5] := 'SFBGS006.esm';
+  wbOfficialDLC[6] := 'SFBGS003.esm';
 
   {
   if wbGameMode = gmSF1VR then begin

--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -4160,9 +4160,9 @@ end;
 
 function TwbFile.GetIsEditable: Boolean;
 begin
-  if wbIsStarfield and Assigned(flModule) then
+  {if wbIsStarfield and Assigned(flModule) then
    if flModule.miExtension = meESP then
-     Exit(False);
+     Exit(False);}
 
   Result :=
     wbIsInternalEdit or
@@ -5065,8 +5065,8 @@ begin
           SetIsLight(True);
       end;
 
-      if flModule.miExtension = meESP then
-        raise Exception.Create('".esp" modules can not be saved in ' + wbAppName + wbToolName);
+      {if flModule.miExtension = meESP then
+        raise Exception.Create('".esp" modules can not be saved in ' + wbAppName + wbToolName);}
     end;
 
     inherited;

--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -2981,8 +2981,8 @@ begin
              wbStarfieldIsABugInfestedHellhole and
              wbIsStarfield and
              (
-               SameText(flMasters[i].FileName, 'Starfield.esm') {or
-               SameText(flMasters[i].FileName, 'BlueprintShips-Starfield.esm')}
+               SameText(flMasters[i].FileName, 'Starfield.esm') or
+               SameText(flMasters[i].FileName, 'BlueprintShips-Starfield.esm')
              )
            )
         then begin
@@ -3240,7 +3240,7 @@ begin
   end;
 
   if wbStarfieldIsABugInfestedHellhole and wbIsStarfield then
-    AddMasters(['Starfield.esm'{, 'BlueprintShips-Starfield.esm'}]);
+    AddMasters(['Starfield.esm', 'BlueprintShips-Starfield.esm']);
 
   BuildOrLoadRef(False);
 end;
@@ -3341,7 +3341,7 @@ begin
             AddMaster(_File);
 
   if wbStarfieldIsABugInfestedHellhole and wbIsStarfield then
-    AddMasters(['Starfield.esm'{, 'BlueprintShips-Starfield.esm'}]);
+    AddMasters(['Starfield.esm', 'BlueprintShips-Starfield.esm']);
 
   BuildOrLoadRef(False);
 end;

--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -2981,8 +2981,8 @@ begin
              wbStarfieldIsABugInfestedHellhole and
              wbIsStarfield and
              (
-               SameText(flMasters[i].FileName, 'Starfield.esm') or
-               SameText(flMasters[i].FileName, 'BlueprintShips-Starfield.esm')
+               SameText(flMasters[i].FileName, 'Starfield.esm') {or
+               SameText(flMasters[i].FileName, 'BlueprintShips-Starfield.esm')}
              )
            )
         then begin
@@ -3240,7 +3240,7 @@ begin
   end;
 
   if wbStarfieldIsABugInfestedHellhole and wbIsStarfield then
-    AddMasters(['Starfield.esm', 'BlueprintShips-Starfield.esm']);
+    AddMasters(['Starfield.esm'{, 'BlueprintShips-Starfield.esm'}]);
 
   BuildOrLoadRef(False);
 end;
@@ -3341,7 +3341,7 @@ begin
             AddMaster(_File);
 
   if wbStarfieldIsABugInfestedHellhole and wbIsStarfield then
-    AddMasters(['Starfield.esm', 'BlueprintShips-Starfield.esm']);
+    AddMasters(['Starfield.esm'{, 'BlueprintShips-Starfield.esm'}]);
 
   BuildOrLoadRef(False);
 end;

--- a/Core/wbLoadOrder.pas
+++ b/Core/wbLoadOrder.pas
@@ -541,12 +541,12 @@ begin
   for i := Low(_ModulesLoadOrder) to High(_ModulesLoadOrder) do
     _ModulesLoadOrder[i].miCombinedIndex := i;
 
+  TwbModuleInfo.AddNewModule('<new file>.esp', True);
+  with TwbModuleInfo.AddNewModule('<new file>.esp', True)^ do begin
+    Include(miFlags, mfHasESMFlag);
+    Include(miFlags, mfIsESM);
+  end;
   if wbGameMode <> gmSF1 then begin
-    TwbModuleInfo.AddNewModule('<new file>.esp', True);
-    with TwbModuleInfo.AddNewModule('<new file>.esp', True)^ do begin
-      Include(miFlags, mfHasESMFlag);
-      Include(miFlags, mfIsESM);
-    end;
     if wbIsLightSupported then begin
       with TwbModuleInfo.AddNewModule('<new file>.esp', True)^ do
         Include(miFlags, mfHasLightFlag);

--- a/xEdit/xeModuleSelectForm.pas
+++ b/xEdit/xeModuleSelectForm.pas
@@ -709,8 +709,8 @@ begin
 
         if lForceLoadStarfieldMasters and
            (
-             SameText(lModule.miName, 'Starfield.esm') or
-             SameText(lModule.miName, 'BlueprintShips-Starfield.esm')
+             SameText(lModule.miName, 'Starfield.esm') {or
+             SameText(lModule.miName, 'BlueprintShips-Starfield.esm')}
            )
         then
           Include(lModule.miFlags, mfForceLoad);

--- a/xEdit/xeModuleSelectForm.pas
+++ b/xEdit/xeModuleSelectForm.pas
@@ -709,8 +709,8 @@ begin
 
         if lForceLoadStarfieldMasters and
            (
-             SameText(lModule.miName, 'Starfield.esm') {or
-             SameText(lModule.miName, 'BlueprintShips-Starfield.esm')}
+             SameText(lModule.miName, 'Starfield.esm') or
+             SameText(lModule.miName, 'BlueprintShips-Starfield.esm')
            )
         then
           Include(lModule.miFlags, mfForceLoad);


### PR DESCRIPTION
As of this writing, there is no safe or convenient way to **edit files created by CK2 in xEdit**—or vice-versa.  This has led to the proliferation of unsafe workarounds among the Starfield community, such as the "[Starfield Plugin Bridge](https://www.nexusmods.com/starfield/mods/10189?tab=description)" tool, or serializing in Spriggit and making changes there—or even manual hex editing! 

Frankly, I feel that this hazardous state of affairs cannot reasonably be allowed to continue.  Therefore, I propose a partial loosening of xEdit restrictions for Starfield—which should, at least, provide a saf**er** alternative to these manual conversion methods. 

This PR aims to improve compatibility between CK2 and xEdit, by reverting a very small subset of xEdit's Starfield-specific sanity checks: 
- Allow creation and editing of 'full' ESP plugins (for later converting in CK2) 
- ~~Do not force load 'BlueprintShips-Starfield.esm'~~ 

Unrelated, but also beneficial in avoiding potential issues: 
- Update the DLC list to match the [Starfield 1.12 hardcoded load order](https://github.com/loot/loot/issues/1989) 