### PR TITLE
*Intense hand related pain.*

### DIFF
--- a/Core/wbDefinitionsCommon.pas
+++ b/Core/wbDefinitionsCommon.pas
@@ -71,6 +71,8 @@ var
   wbHEDR: IwbRecordMemberDef;
   wbINOA: IwbRecordMemberDef;
   wbINOM: IwbRecordMemberDef;
+  wbQSTI: IwbRecordMemberDef;
+  wbQSTR: IwbRecordMemberDef;
   wbKWDAs: IwbRecordMemberDef;
   wbKeywords :IwbRecordMemberDef;
   wbMagicEffectSounds: IwbRecordMemberDef;
@@ -400,10 +402,11 @@ function wbBelowVersion(aVersion: Integer; const aValue: IwbValueDef): IwbValueD
 function wbFromVersion(aVersion: Integer; const aSignature: TwbSignature; const aValue: IwbValueDef): IwbRecordMemberDef; overload;
 function wbFromVersion(aVersion: Integer; const aValue: IwbValueDef): IwbValueDef; overload;
 
-{>>> Vec3 Defs <<<} //11
+{>>> Vec3 Defs <<<} //12
 function wbVec3(const aName: string = 'Unknown'; const aPrefix: string = ''): IwbValueDef; overload;
 function wbVec3(const aSignature: TwbSignature; const aName: string = 'Unknown'; const aPrefix: string = ''): IwbRecordMemberDef; overload;
 function wbVec3Pos(const aName: string = 'Position'; const aPrefix: string = 'Pos'): IwbValueDef; overload;
+function wbVec3PosInt32(const aName: string = 'Position'; const aPrefix: string = 'Pos'): IwbValueDef; overload;
 function wbVec3Pos(const aSignature: TwbSignature; const aName: string = 'Position'; const aPrefix: string = 'Pos'): IwbRecordMemberDef; overload;
 function wbVec3Rot(const aName: string = 'Rotation'; const aPrefix: string = 'Rot'): IwbValueDef; overload;
 function wbVec3Rot(const aSignature: TwbSignature; const aName: string = 'Rotation'; const aPrefix: string = 'Rot'): IwbRecordMemberDef; overload;
@@ -413,11 +416,13 @@ function wbVec3PosRotDegrees(const aCombinedName: string = 'Position/Rotation'; 
 function wbVec3PosRotDegrees(const aSignature: TwbSignature; const aCombinedName: string = 'Position/Rotation'; aPosName: string = 'Position'; const aRotName: string = 'Rotation'; const aPosPrefix: string ='Pos'; const aRotPrefix: string = 'Rot'): IwbRecordMemberDef; overload;
 function wbSizePosRot(aSignature: TwbSignature; aName: string; aPriority: TwbConflictPriority = cpNormal): IwbSubRecordDef; overload;
 
-{>>> Color Defs <<<} //16
+{>>> Color Defs <<<} //18
 function wbAmbientColors(const aSignature: TwbSignature; const aName: string = 'Directional Ambient Lighting Colors'): IwbSubRecordDef; overload;
 function wbAmbientColors(const aName: string = 'Directional Ambient Lighting Colors'): IwbStructDef; overload;
 function wbByteColors(const aSignature: TwbSignature; const aName: string = 'Color'): IwbRecordMemberDef; overload;
 function wbByteColors(const aName: string = 'Color'): IwbValueDef; overload;
+function wbByteColorsRGB(const aName: string = 'Color'): IwbValueDef; overload;
+function wbByteColorsInt32(const aName: string = 'Color'): IwbValueDef; overload;
 function wbByteABGR(const aSignature: TwbSignature; const aName: string = 'Color'): IwbRecordMemberDef; overload;
 function wbByteABGR(const aName: string = 'Color'): IwbValueDef; overload;
 function wbByteRGBA(const aSignature: TwbSignature; const aName: string = 'Color'): IwbRecordMemberDef; overload;
@@ -1284,12 +1289,12 @@ end;
 
 function wbCellInteriorDontShow(const aElement: IwbElement): Boolean;
 begin
-  Result := (aElement.ContainingMainRecord.ElementNativeValues['DATA'] and 1 = 1);
+  Result := (aElement.ContainingMainRecord.ElementNativeValues[IfThen(wbIsMorrowind, 'DATA\Flags', 'DATA')] and 1 = 1);
 end;
 
 function wbCellExteriorDontShow(const aElement: IwbElement): Boolean;
 begin
-  Result := (aElement.ContainingMainRecord.ElementNativeValues['DATA'] and 1 = 0);
+  Result := (aElement.ContainingMainRecord.ElementNativeValues[IfThen(wbIsMorrowind, 'DATA\Flags', 'DATA')] and 1 = 0);
 end;
 
 function wbModelInfoDontShow(const aElement: IwbElement): Boolean;
@@ -2590,16 +2595,16 @@ begin
   if not Assigned(Faction.LinksTo) then
     Exit;
 
-  var Rank := Container.Elements[1];
+  var Reaction := Container.Elements[1];
 
   aValue := Faction.Value;
 
   if wbIsOblivion then begin
-    var NativeRank := Rank.NativeValue;
+    var NativeReaction := Reaction.NativeValue;
 
-    aValue := IntToStr(NativeRank) + ' ' + aValue;
+    aValue := IntToStr(NativeReaction) + ' ' + aValue;
 
-    if NativeRank >= 0 then
+    if NativeReaction >= 0 then
       aValue := '+' + aValue;
 
     Exit;
@@ -2860,7 +2865,7 @@ begin
   if not wbTrySetContainer(aElement, aType, CER) then
     Exit;
 
-  var eSCDA := CER.ElementBySignature[SCDA];
+  var eSCDA := [IfThen(wbIsMorrowind, SCDA, SCDT)];
   var eSCTX := CER.ElementBySignature[SCTX];
 
   if not Assigned(eSCDA) then begin
@@ -4114,6 +4119,21 @@ begin
   Result := wbSubRecord(aSignature, aName, wbVec3Pos(''));
 end;
 
+function wbVec3PosInt32(const aName: string = 'Position'; const aPrefix: string = 'Pos'): IwbValueDef;
+begin
+  Result :=
+    wbStruct(aName, [
+      wbInteger('X', itS32),
+      wbInteger('Y', itS32),
+      wbInteger('Z', itS32)
+    ]).SetSummaryKey([0, 1, 2])
+      .SetSummaryMemberPrefixSuffix(0, aPrefix + '(', '')
+      .SetSummaryMemberPrefixSuffix(2, '', ')')
+      .SetSummaryDelimiter(', ')
+      .IncludeFlag(dfSummaryMembersNoName)
+      .IncludeFlag(dfCollapsed, wbCollapseVec3);
+end;
+
 function wbVec3Rot(const aName: string = 'Rotation'; const aPrefix: string = 'Rot'): IwbValueDef;
 begin
   Result :=
@@ -4194,7 +4214,7 @@ begin
     ], aPriority);
 end;
 
-{>>> Color Defs <<<} //16
+{>>> Color Defs <<<} //18
 
 function wbAmbientColors(const aSignature: TwbSignature; const aName: string = 'Directional Ambient Lighting Colors'): IwbSubRecordDef;
 begin
@@ -4264,6 +4284,26 @@ begin
     wbInteger('Green', itU8),
     wbInteger('Blue', itU8),
     wbUnused(1)
+  ]).SetToStr(wbRGBAToStr)
+    .IncludeFlag(dfCollapsed, wbCollapseRGBA);
+end;
+
+function wbByteColorsRGB(const aName: string = 'Color'): IwbValueDef;
+begin
+  Result := wbStruct(aName, [
+    wbInteger('Red', itU8),
+    wbInteger('Green', itU8),
+    wbInteger('Blue', itU8)
+  ]).SetToStr(wbRGBAToStr)
+    .IncludeFlag(dfCollapsed, wbCollapseRGBA);
+end;
+
+function wbByteColorsInt32(const aName: string = 'Color'): IwbValueDef;
+begin
+  Result := wbStruct(aName, [
+    wbInteger('Red', itU32),
+    wbInteger('Green', itU32),
+    wbInteger('Blue', itU32)
   ]).SetToStr(wbRGBAToStr)
     .IncludeFlag(dfCollapsed, wbCollapseRGBA);
 end;
@@ -5578,7 +5618,7 @@ begin
       {0} 'Male',
       {1} 'Female'
     ], [
-      -1, 'None'
+      -1, IsTES3('None', '')
     ]);
 
   wbSoulGemEnum :=
@@ -5684,7 +5724,7 @@ begin
          IsSF1    ('Weapon Drawn: Ready',
                    'Wear Sleep Outfit')),
      30, IsSF1    ('Group Package', ''),
-     31, IsSF1    ('Weapon Drawr: Alert', '')
+     31, IsSF1    ('Weapon Drawn: Alert', '')
     ]), True);
 
   wbServiceFlags :=
@@ -5701,8 +5741,9 @@ begin
       {6}  IsTES3('Probes',
            IsFO3 ('Stimpaks', '')),
       {7}  IsFO3 ('', 'Lights'),
-      {8}  IsFO3 ('', 'Apparatus'),
-      {9}  IsTES4('Repair', ''),
+      {8}  IsFO3 ('', 'Alchemical Apparatus'),
+      {9}  IsTES3('Repair',
+           IsTES4('Repair', '')),
       {10}        'Miscellaneous',
       {11} IsFO3 ('', 'Spells'),
       {12} IsFO3 ('', 'Magic Items'),
@@ -6004,6 +6045,14 @@ begin
     ).IncludeFlag(dfInternalEditOnly)
      .IncludeFlag(dfDontSave)
      .IncludeFlag(dfDontAssign);
+
+  wbQSTI :=
+    wbRArrayS('Associated Quests', wbFormIDCkNoReach(QSTI, 'Associated Quest', [QUST], False, cpBenign));
+
+  wbQSTR :=
+    wbRArrayS('Removed Quests', wbFormIDCkNoReach(QSTR, 'Removed Quest', [QUST], False, cpBenign));
+
+
 
 {>>>Landscape Common Defs<<<}
   //TES4,FO3,FNV,TES5,FO4,FO76,SF1

--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -4125,8 +4125,8 @@ begin
 
   wbRecord(DIAL, 'Dialog Topic', [
     wbEDIDReqKC,
-    wbRArrayS('Quests', wbFormIDCkNoReach(QSTI, 'Quest', [QUST], False, cpBenign)),
-    wbRArrayS('Quests?', wbFormIDCkNoReach(QSTR, 'Quest?', [QUST], False, cpBenign)),
+    wbQSTI,
+    wbQSTR,
     wbFULL,
     wbFloat(PNAM, 'Priority')
       .SetDefaultNativeValue(50)

--- a/Core/wbDefinitionsTES3.pas
+++ b/Core/wbDefinitionsTES3.pas
@@ -24,7 +24,6 @@ uses
 
 var
   wbAttributeEnum,
-  wbBipedObjectEnum,
   wbDialogTypeEnum,
   wbMagicEffectEnum,
   wbSkillEnum,
@@ -35,11 +34,17 @@ var
   wbAIDT,
   wbBipedObjects,
   wbDELE,
+  wbDESC,
+  wbEffects,
   wbENAM,
   wbFNAM,
+  wbITEX,
+  wbItems,
   wbMODL,
   wbNAME,
+  wbPackages,
   wbSCRI,
+  wbSpells,
   wbTravelServices: IwbRecordMemberDef;
 
 const
@@ -77,7 +82,7 @@ const
 
   wbKnownSubRecordSignaturesINDX : TwbKnownSubRecordSignatures = (
     'INDX',
-    '____',
+    'DESC',
     '____',
     '____',
     '____'
@@ -93,7 +98,7 @@ const
 
   wbKnownSubRecordSignaturesSSCR : TwbKnownSubRecordSignatures = (
     'DATA',
-    '____',
+    'NAME',
     '____',
     '____',
     '____'
@@ -116,6 +121,14 @@ begin
   Result := ((aElement.Container.Container as IwbMainRecord).RecordBySignature['PGRP'].Elements[Pred(Index)] as IwbContainer).Elements[2].NativeValue;
 end;
 
+function wbDialogDataDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
+begin
+  Result := 0;
+  if Assigned(aElement) then
+    if aElement.DataSize = 4 then
+      Result := 1;
+end;
+
 function wbFRMRToString(aInt: Int64; const aElement: IwbElement; aType: TwbCallbackType): string;
 begin
   Result := '';
@@ -126,24 +139,7 @@ begin
   end;
 end;
 
-function wbGLOBUnionDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
-begin
-  Result := 0;
-  if not Assigned(aElement) then
-    Exit;
-  var rValue := aElement.Container.RecordBySignature[FNAM];
-  if Assigned(rValue) then begin
-    var s := rValue.Value;
-    if Length(s) > 0 then
-      case s[1] of
-        'S': Result := 0;
-        'L': Result := 1;
-        'F': Result := 2;
-      end;
-  end;
-end;
-
-function GridCellToFormID(aFormIDBase: Byte; const aGridCell: TwbGridCell; out aFormID: TwbFormID): Boolean;
+function wbGridCellToFormID(aFormIDBase: Byte; const aGridCell: TwbGridCell; out aFormID: TwbFormID): Boolean;
 begin
   Result := False;
   with aGridCell do begin
@@ -155,13 +151,200 @@ begin
 end;
 
 function wbNPCDataDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
-var
-  SubRecord: IwbSubRecord;
 begin
   Result := 0;
-  if Assigned(aElement) and Supports(aElement.Container, IwbSubRecord, SubRecord) then
-    if SubRecord.SubRecordHeaderSize = 12 then
+  if Assigned(aElement) then
+    if aElement.DataSize = 12 then
       Result := 1;
+end;
+
+function wbSkillDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
+var
+  Container : IwbContainer;
+  INDX      : IwbElement;
+begin
+  Result := 0;
+  if not wbTryGetContainerFromUnion(aElement, Container) then
+    Exit;
+
+  Container := Container.Container;
+  if not Assigned(Container) then
+    Exit;
+
+  INDX := Container.ElementBySignature['INDX'];
+  if not Assigned(INDX) then
+    Exit;
+
+  var i := INDX.NativeValue;
+  case i of
+    1: Result := 1;
+    2,3,17,21: Result := 2;
+    4,5,6,7,22,23,26: Result := 3;
+    8: Result := 4;
+    9: Result := 5;
+    10,11,12,13,14,15: Result := 6;
+    16: Result := 7;
+    18: Result := 8;
+    19: Result := 9;
+    20: Result := 10;
+    24: Result := 11;
+    25: Result := 12;
+  end;
+end;
+
+function wbConditionDecider(aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement): Integer;
+var
+  Container : IwbContainer;
+begin
+  Result := 0;
+  if not wbTryGetContainerFromUnion(aElement, Container) then
+    Exit;
+
+  case (Container.ElementNativeValues['Type']) of
+    $32, $33, $43: Result := 1;
+    $34, $35, $36, $37, $38, $39, $41, $42: Result := 2;
+  end;
+end;
+
+procedure wbCELLAfterLoad(const aElement: IwbElement);
+var
+  Container  : IwbContainerElementRef;
+  MainRecord : IwbMainRecord;
+begin
+  if wbBeginInternalEdit then try
+    if not wbTryGetContainerWithValidMainRecord(aElement, Container, MainRecord) then
+      Exit;
+
+    if (Container.ElementNativeValues['DATA\Flags'] and 1) <> 0 then begin
+      if not Assigned(MainRecord.ElementBySignature['WHGT']) then begin
+        Container.ElementNativeValues['WHGT'] := Container.ElementNativeValues['INTV'];
+        Container.RemoveElement('INTV');
+      end;
+    end;
+  finally
+    wbEndInternalEdit;
+  end;
+end;
+
+procedure wbDELEAfterLoad(const aElement: IwbElement);
+var
+  Container  : IwbContainerElementRef;
+  MainRecord : IwbMainRecord;
+begin
+  if wbBeginInternalEdit then try
+    if not wbTryGetContainerWithValidMainRecord(aElement, Container, MainRecord) then
+      Exit;
+
+    if Assigned(MainRecord.ElementBySignature['DELE']) then
+      Container.ElementNativeValues['DELE'] := 0;
+  finally
+    wbEndInternalEdit;
+  end;
+end;
+
+//There are several errors in the Morrowind.esm with invalid values for FLTV.
+procedure wbGlobalAfterLoad(const aElement: IwbElement);
+var
+  Container  : IwbContainerElementRef;
+  MainRecord : IwbMainRecord;
+begin
+  if wbBeginInternalEdit then try
+    if not wbTryGetContainerWithValidMainRecord(aElement, Container, MainRecord) then
+      Exit;
+
+    if Assigned(MainRecord.ElementBySignature['FLTV']) then
+      if MainRecord.ElementBySignature['FNAM'].Value = 'Short' then //Only occurs on shorts.
+        if (MainRecord.ElementBySignature['FLTV'].NativeValue = -92233720368547758.1) or
+           (MainRecord.ElementBySignature['FLTV'].NativeValue = 0.04) or
+           (MainRecord.ElementBySignature['FLTV'].Value = 'NaN') then
+          Container.ElementNativeValues['FLTV'] := 0; //All errors are zero in the CS.
+  finally
+    wbEndInternalEdit;
+  end;
+end;
+
+procedure wbFactionReactionToStr(var aValue: string; aBasePtr: Pointer; aEndPtr: Pointer; const aElement: IwbElement; aType: TwbCallbackType);
+var
+  Container: IwbContainerElementRef;
+begin
+  if not wbTrySetContainer(aElement, aType, Container) then
+    Exit;
+
+  var Faction := Container.Elements[0];
+  var Reaction := Container.Elements[1].NativeValue;
+  aValue := IntToStr(Reaction) + ' ' + Faction.Value;
+  if Reaction >= 0 then
+    aValue := '+' + aValue;
+end;
+
+//Work around for forwarding bug when a wbString is forwarded inside a member def.
+procedure wbForwardForRealz(const aElement: IwbElement);
+var
+  Container : IwbContainer;
+  Element   : IwbElement;
+begin
+  if wbBeginInternalEdit then try
+    if Length(aElement.Value) > 0 then begin
+      Container := aElement.Container;
+      Element := Container.ElementbyName['Target'];
+      if not Assigned(Element) then
+        Element := Container.ElementbyName['Sound'];
+        if not Assigned(Element) then
+          Exit;
+
+        var i := 1;
+        while i <= Length(aElement.Value) do begin
+          if aElement.Value[i] = AnsiChar(#0) then
+            Break;
+          Inc(i);
+        end;
+        var s := Copy(aElement.Value, 0, i);
+        Element.NativeValue := s;
+     end;
+  finally
+    wbEndInternalEdit;
+  end;
+end;
+
+procedure wbINGRAfterLoad(const aElement: IwbElement);
+var
+  Container  : IwbContainerElementRef;
+  MainRecord : IwbMainRecord;
+begin
+  if wbBeginInternalEdit then try
+    if not wbTryGetContainerWithValidMainRecord(aElement, Container, MainRecord) then
+      Exit;
+
+    var i : integer;
+    for i := 0 to 3 do begin
+      case (Container.ElementNativeValues['IRDT\Effects\Magic Effects\Magic Effect #' + IntToStr(i)]) of
+        17, 22, 74, 79: Container.ElementNativeValues['IRDT\Effects\Skills\Skill #' + IntToStr(i)] := -1;
+        21, 26, 78, 83: Container.ElementNativeValues['IRDT\Effects\Attributes\Attribute #' + IntToStr(i)] := -1;
+      else
+        Container.ElementNativeValues['IRDT\Effects\Skills\Skill #' + IntToStr(i)] := -1;
+        Container.ElementNativeValues['IRDT\Effects\Attributes\Attribute #' + IntToStr(i)] := -1;
+      end;
+    end;
+  finally
+    wbEndInternalEdit;
+  end;
+end;
+
+procedure wbTES3Header(const aElement: IwbElement);
+var
+  Container  : IwbContainerElementRef;
+  MainRecord : IwbMainRecord;
+begin
+  if wbBeginInternalEdit then try
+    if not wbTryGetContainerWithValidMainRecord(aElement, Container, MainRecord) then
+      Exit;
+
+      if Assigned(MainRecord.ElementBySignature['HEDR']) then
+        if (Container.ElementNativeValues['HEDR\Record Flags'] and 1) = 1 then
+          MainRecord.SetIsESM(True);
+  finally
+    wbEndInternalEdit;
+  end;
 end;
 
 procedure DefineTES3;
@@ -169,14 +352,7 @@ begin
   DefineCommon;
   wbHeaderSignature := 'TES3';
 
-  wbRecordFlags :=
-    wbInteger('Record Flags', itU32,
-      wbFlags(wbSparseFlags([
-        0,  'ESM',
-        5,  'Deleted',
-        10, 'Persistent Reference',
-        13, 'Blocked'
-      ], False, 14)));
+  wbRecordFlags := wbInteger('Record Flags', itU32, wbFlags(['ESM']));
 
   wbMainRecordHeader := wbStruct('Record Header', [
     wbString('Signature', 4, cpCritical),
@@ -208,37 +384,6 @@ begin
       -1, 'None'
     ]);
 
-  wbBipedObjectEnum :=
-    wbEnum ([
-      {0}  'Head',
-      {1}  'Hair',
-      {2}  'Neck',
-      {3}  'Chest',
-      {4}  'Groin',
-      {5}  'Skirt',
-      {6}  'Right Hand',
-      {7}  'Left Hand',
-      {8}  'Right Wrist',
-      {9}  'Left Wrist',
-      {10} 'Shield',
-      {11} 'Right Forearm',
-      {12} 'Left Forearm',
-      {13} 'Right Upper Arm',
-      {14} 'Left Upper Arm',
-      {15} 'Right Foot',
-      {16} 'Left Foot',
-      {17} 'Right Ankle',
-      {18} 'Left Ankle',
-      {19} 'Right Knee',
-      {20} 'Left Knee',
-      {21} 'Right Upper Leg',
-      {22} 'Left Upper Leg',
-      {23} 'Right Pauldron',
-      {24} 'Left Pauldron',
-      {25} 'Weapon',
-      {26} 'Tail'
-    ]);
-
   wbDialogTypeEnum :=
     wbEnum([
       {0} 'Regular Topic',
@@ -250,106 +395,106 @@ begin
 
   wbMagicEffectEnum :=
     wbEnum([
-      {0}   'Water Breathing',
-      {1}   'Swift Swim',
-      {2}   'Water Walking',
-      {3}   'Shield',
-      {4}   'Fire Shield',
-      {5}   'Lightning Shield',
-      {6}   'Frost Shield',
-      {7}   'Burden',
-      {8}   'Feather',
-      {9}   'Jump',
-      {10}  'Levitate',
-      {11}  'Slow Fall',
-      {12}  'Lock',
-      {13}  'Open',
-      {14}  'Fire Damage',
-      {15}  'Shock Damage',
-      {16}  'Frost Damage',
-      {17}  'Drain Attribute',
-      {18}  'Drain Health',
-      {19}  'Drain Spell Points',
-      {20}  'Drain Fatigue',
-      {21}  'Drain Skill',
-      {22}  'Damage Attribute',
-      {23}  'Damage Health',
-      {24}  'Damage Magicka',
-      {25}  'Damage Fatigue',
-      {26}  'Damage Skill',
-      {27}  'Poison',
-      {28}  'Weakness To Fire',
-      {29}  'Weakness To Frost',
-      {30}  'Weakness To Shock',
-      {31}  'Weakness To Magicka',
-      {32}  'Weakness To Common Disease',
-      {33}  'Weakness To Blight Disease',
-      {34}  'Weakness To Corprus Disease',
-      {35}  'Weakness To Poison',
-      {36}  'Weakness To Normal Weapons',
-      {37}  'Disintegrate Weapon',
-      {38}  'Disintegrate Armor',
-      {39}  'Invisibility',
-      {40}  'Chameleon',
-      {41}  'Light',
-      {42}  'Sanctuary',
-      {43}  'Night Eye',
-      {44}  'Charm',
-      {45}  'Paralyze',
-      {46}  'Silence',
-      {47}  'Blind',
-      {48}  'Sound',
-      {49}  'Calm Humanoid',
-      {50}  'Calm Creature',
-      {51}  'Frenzy Humanoid',
-      {52}  'Frenzy Creature',
-      {53}  'Demoralize Humanoid',
-      {54}  'Demoralize Creature',
-      {55}  'Rally Humanoid',
-      {56}  'Rally Creature',
-      {57}  'Dispel',
-      {58}  'Soultrap',
-      {59}  'Telekinesis',
-      {60}  'Mark',
-      {61}  'Recall',
-      {62}  'Divine Intervention',
-      {63}  'Almsivi Intervention',
-      {64}  'Detect Animal',
-      {65}  'Detect Enchantment',
-      {66}  'Detect Key',
-      {67}  'Spell Absorption',
-      {68}  'Reflect',
-      {69}  'Cure Common Disease',
-      {70}  'Cure Blight Disease',
-      {71}  'Cure Corprus Disease',
-      {72}  'Cure Poison',
-      {73}  'Cure Paralyzation',
-      {74}  'Restore Attribute',
-      {75}  'Restore Health',
-      {76}  'Restore Spell Points',
-      {77}  'Restore Fatigue',
-      {78}  'Restore Skill',
-      {79}  'Fortify Attribute',
-      {80}  'Fortify Health',
-      {81}  'Fortify Spell Points',
-      {82}  'Fortify Fatigue',
-      {83}  'Fortify Skill',
-      {84}  'Fortify Magicka Multiplier',
-      {85}  'Absorb Attribute',
-      {86}  'Absorb Health',
-      {87}  'Absorb Spell Points',
-      {88}  'Absorb Fatigue',
-      {89}  'Absorb Skill',
-      {90}  'Resist Fire',
-      {91}  'Resist Frost',
-      {92}  'Resist Shock',
-      {93}  'Resist Magicka',
-      {94}  'Resist Common Disease',
-      {95}  'Resist Blight Disease',
-      {96}  'Resist Corprus Disease',
-      {97}  'Resist Poison',
-      {98}  'Resist Normal Weapons',
-      {99}  'Resist Paralysis',
+        {0} 'Water Breathing',
+        {1} 'Swift Swim',
+        {2} 'Water Walking',
+        {3} 'Shield',
+        {4} 'Fire Shield',
+        {5} 'Lightning Shield',
+        {6} 'Frost Shield',
+        {7} 'Burden',
+        {8} 'Feather',
+        {9} 'Jump',
+       {10} 'Levitate',
+       {11} 'Slow Fall',
+       {12} 'Lock',
+       {13} 'Open',
+       {14} 'Fire Damage',
+       {15} 'Shock Damage',
+       {16} 'Frost Damage',
+       {17} 'Drain Attribute',
+       {18} 'Drain Health',
+       {19} 'Drain Magicka',
+       {20} 'Drain Fatigue',
+       {21} 'Drain Skill',
+       {22} 'Damage Attribute',
+       {23} 'Damage Health',
+       {24} 'Damage Magicka',
+       {25} 'Damage Fatigue',
+       {26} 'Damage Skill',
+       {27} 'Poison',
+       {28} 'Weakness To Fire',
+       {29} 'Weakness To Frost',
+       {30} 'Weakness To Shock',
+       {31} 'Weakness To Magicka',
+       {32} 'Weakness To Common Disease',
+       {33} 'Weakness To Blight Disease',
+       {34} 'Weakness To Corprus Disease',
+       {35} 'Weakness To Poison',
+       {36} 'Weakness To Normal Weapons',
+       {37} 'Disintegrate Weapon',
+       {38} 'Disintegrate Armor',
+       {39} 'Invisibility',
+       {40} 'Chameleon',
+       {41} 'Light',
+       {42} 'Sanctuary',
+       {43} 'Night Eye',
+       {44} 'Charm',
+       {45} 'Paralyze',
+       {46} 'Silence',
+       {47} 'Blind',
+       {48} 'Sound',
+       {49} 'Calm Humanoid',
+       {50} 'Calm Creature',
+       {51} 'Frenzy Humanoid',
+       {52} 'Frenzy Creature',
+       {53} 'Demoralize Humanoid',
+       {54} 'Demoralize Creature',
+       {55} 'Rally Humanoid',
+       {56} 'Rally Creature',
+       {57} 'Dispel',
+       {58} 'Soultrap',
+       {59} 'Telekinesis',
+       {60} 'Mark',
+       {61} 'Recall',
+       {62} 'Divine Intervention',
+       {63} 'Almsivi Intervention',
+       {64} 'Detect Animal',
+       {65} 'Detect Enchantment',
+       {66} 'Detect Key',
+       {67} 'Spell Absorption',
+       {68} 'Reflect',
+       {69} 'Cure Common Disease',
+       {70} 'Cure Blight Disease',
+       {71} 'Cure Corprus Disease',
+       {72} 'Cure Poison',
+       {73} 'Cure Paralyzation',
+       {74} 'Restore Attribute',
+       {75} 'Restore Health',
+       {76} 'Restore Magicka',
+       {77} 'Restore Fatigue',
+       {78} 'Restore Skill',
+       {79} 'Fortify Attribute',
+       {80} 'Fortify Health',
+       {81} 'Fortify Magicka',
+       {82} 'Fortify Fatigue',
+       {83} 'Fortify Skill',
+       {84} 'Fortify Maximum Magicka',
+       {85} 'Absorb Attribute',
+       {86} 'Absorb Health',
+       {87} 'Absorb Magicka',
+       {88} 'Absorb Fatigue',
+       {89} 'Absorb Skill',
+       {90} 'Resist Fire',
+       {91} 'Resist Frost',
+       {92} 'Resist Shock',
+       {93} 'Resist Magicka',
+       {94} 'Resist Common Disease',
+       {95} 'Resist Blight Disease',
+       {96} 'Resist Corprus Disease',
+       {97} 'Resist Poison',
+       {98} 'Resist Normal Weapons',
+       {99} 'Resist Paralysis',
       {100} 'Remove Curse',
       {101} 'Turn Undead',
       {102} 'Summon Scamp',
@@ -368,8 +513,8 @@ begin
       {115} 'Summon Frost Atronach',
       {116} 'Summon Storm Atronach',
       {117} 'Fortify Attack Bonus',
-      {118} 'Command Creatures',
-      {119} 'Command Humanoids',
+      {118} 'Command Creature',
+      {119} 'Command Humanoid',
       {120} 'Bound Dagger',
       {121} 'Bound Longsword',
       {122} 'Bound Mace',
@@ -399,16 +544,16 @@ begin
 
   wbSkillEnum :=
     wbEnum([
-      {0}  'Block',
-      {1}  'Armorer',
-      {2}  'Medium Armor',
-      {3}  'Heavy Armor',
-      {4}  'Blunt Weapon',
-      {5}  'Long Blade',
-      {6}  'Axe',
-      {7}  'Spear',
-      {8}  'Athletics',
-      {9}  'Enchant',
+       {0} 'Block',
+       {1} 'Armorer',
+       {2} 'Medium Armor',
+       {3} 'Heavy Armor',
+       {4} 'Blunt Weapon',
+       {5} 'Long Blade',
+       {6} 'Axe',
+       {7} 'Spear',
+       {8} 'Athletics',
+       {9} 'Enchant',
       {10} 'Destruction',
       {11} 'Alteration',
       {12} 'Illusion',
@@ -425,7 +570,7 @@ begin
       {23} 'Marksman',
       {24} 'Mercantile',
       {25} 'Speechcraft',
-      {26} 'Hand-To-Hand'
+      {26} 'Hand-to-Hand'
     ], [
       -1, 'None'
     ]);
@@ -447,56 +592,152 @@ begin
 
   {>>> Common Defs <<<}
 
-  wbDELE := wbInteger(DELE, 'Deleted', itU32, wbEnum(['Deleted']));
+  wbDELE := wbInteger(DELE, 'Deleted', itU32, wbEnum(['True']));
+  wbDESC := wbString(DESC, 'Description');
   wbFNAM := wbString(FNAM, 'Name');
+  wbITEX := wbString(ITEX, 'Icon Filename');
   wbMODL := wbString(MODL, 'Model Filename');
-  wbNAME := wbString(NAME, 'Editor ID');
-  wbSCRI := wbString(SCRI, 'Script');
+  wbNAME := wbString(NAME, 'Editor ID').SetRequired.IncludeFlag(dfSummarySelfAsShortName);
+  wbSCRI := wbString(SCRI, 'Script'); //[SCPT]
+  wbENAM := wbString(ENAM, 'Enchanment'); //[ENCH]
+
   {>>> Record Members <<<}
 
   wbAIDT :=
     wbStruct(AIDT, 'AI Data', [
-      wbInteger('Hello', itU16),
-      wbInteger('Fight', itU8),
-      wbInteger('Flee', itU8),
+      wbInteger('Hello', itU16).SetDefaultNativeValue(30), //0 CREA
+      wbInteger('Fight', itU8).SetDefaultNativeValue(30), //90 CREA
+      wbInteger('Flee', itU8).SetDefaultNativeValue(30), //20 CREA
       wbInteger('Alarm', itU8),
       wbUnused(3),
-      wbInteger('Service Flags', itU32, wbServiceFlags)
+      wbInteger('Buy/Sell Service Flags', itU32, wbServiceFlags).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired;
 
   wbBipedObjects :=
-    wbRArray('Biped Objects',
-      wbRStruct('Biped Object', [
-        wbInteger(INDX, 'Body Part', itU8, wbBipedObjectEnum),
-        wbString(BNAM, 'Male Armor'), //[BODY]
-        wbString(CNAM, 'Female Armor') //[BODY]
-      ]).SetRequired);
+    wbRArrayS('Biped Objects',
+      wbRStructSK([0], 'Biped Object', [
+        wbInteger(INDX, 'Body Part', itU8, wbEnum([
+           {0} 'Head',
+           {1} 'Hair',
+           {2} 'Neck',
+           {3} 'Chest',
+           {4} 'Groin',
+           {5} 'Skirt',
+           {6} 'Right Hand',
+           {7} 'Left Hand',
+           {8} 'Right Wrist',
+           {9} 'Left Wrist',
+          {10} 'Shield',
+          {11} 'Right Forearm',
+          {12} 'Left Forearm',
+          {13} 'Right Upper Arm',
+          {14} 'Left Upper Arm',
+          {15} 'Right Foot',
+          {16} 'Left Foot',
+          {17} 'Right Ankle',
+          {18} 'Left Ankle',
+          {19} 'Right Knee',
+          {20} 'Left Knee',
+          {21} 'Right Upper Leg',
+          {22} 'Left Upper Leg',
+          {23} 'Right Pauldron',
+          {24} 'Left Pauldron',
+          {25} 'Weapon',
+          {26} 'Tail'
+        ])),
+        wbString(BNAM, 'Male'), //[BODY]
+        wbString(CNAM, 'Female') //[BODY]
+      ]).SetSummaryKey([0, 1, 2])
+        .SetSummaryMemberPrefixSuffix(0, 'Part: ', ',')
+        .SetSummaryMemberPrefixSuffix(1, 'Male: ', ',')
+        .SetSummaryMemberPrefixSuffix(2, 'Female: ', '')
+        .IncludeFlag(dfSummaryMembersNoName)
+        .IncludeFlag(dfSummaryNoSortKey)
+        .IncludeFlag(dfCollapsed, wbCollapseBodyParts));
 
-  wbENAM :=
+  wbEffects :=
     wbRArray('Effects',
-      wbStruct(ENAM, 'Effect', [
-        wbInteger('Magic Effect', itU16, wbMagicEffectEnum), //[MGEF]
-        wbInteger('Skill', itS8, wbSkillEnum), //[SKIL]
-        wbInteger('Attribute', itS8, wbAttributeEnum),
+      wbStructSK(ENAM, [0], 'Effect', [
+        wbInteger('Magic Effect', itU16, wbMagicEffectEnum).SetDefaultNativeValue(-1),
+        wbInteger('Skill', itS8, wbSkillEnum).SetDefaultNativeValue(-1),
+        wbInteger('Attribute', itS8, wbAttributeEnum).SetDefaultNativeValue(-1),
         wbInteger('Range', itU32,
           wbEnum([
             {0} 'Self',
             {1} 'Touch',
             {2} 'Target'
           ])),
-        wbInteger('Area', itS32),
-        wbInteger('Duration', itS32),
-        wbInteger('Magnitude Minimum', itS32),
-        wbInteger('Magnitude Maximum', itS32)
-      ]).SetRequired);
+        wbInteger('Area', itU32),
+        wbInteger('Duration', itU32),
+        wbInteger('Magnitude Minimum', itU32),
+        wbInteger('Magnitude Maximum', itU32)
+      ]).SetSummaryKeyOnValue([0, 3, 1, 2])
+        .SetSummaryPrefixSuffixOnValue(0, 'MGEF: ', ',')
+        .SetSummaryPrefixSuffixOnValue(3, 'Range: ', ',')
+        .SetSummaryPrefixSuffixOnValue(1, 'Skill: ', ',')
+        .SetSummaryPrefixSuffixOnValue(2, 'Attribute: ', '')
+        .IncludeFlag(dfSummaryMembersNoName)
+        .IncludeFlag(dfSummaryNoSortKey));
+
+  wbItems :=
+    wbRArrayS('Item Entries',
+      wbStructSK(NPCO, [1], 'Item Entry', [
+        wbInteger('Count', itS32),
+        wbString('Item', 32) //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LEVI, LIGH, LOCK, MISC, PROB, REPA, WEAP]
+      ]).SetSummaryKeyOnValue([1, 0])
+        .SetSummaryPrefixSuffixOnValue(0, 'x', '}')
+        .SetSummaryPrefixSuffixOnValue(1, '{', '')
+        .IncludeFlag(dfCollapsed, wbCollapseItems));
+
+  wbPackages :=
+    wbRArray('AI Packages',
+      wbRUnion('AI Packages', [
+        wbStruct(AI_W, 'AI Wander', [
+          wbInteger('Distance', itU16).SetDefaultNativeValue(512),
+          wbInteger('Duration (Hours)', itU16).SetDefaultNativeValue(5),
+          wbInteger('Time of Day', itU8),
+          wbStruct('Idle Chances', [
+            wbInteger('Idle 2', itU8).SetDefaultNativeValue(60),
+            wbInteger('Idle 3', itU8).SetDefaultNativeValue(20),
+            wbInteger('Idle 4', itU8).SetDefaultNativeValue(10),
+            wbInteger('Idle 5', itU8),
+            wbInteger('Idle 6', itU8),
+            wbInteger('Idle 7', itU8),
+            wbInteger('Idle 8', itU8),
+            wbInteger('Idle 9', itU8)
+          ]),
+          wbInteger('Reset', itU8, wbBoolEnum).SetDefaultNativeValue(1)
+        ]),
+        wbStruct(AI_T, 'AI Travel', [
+          wbVec3('Location'),
+          wbInteger('Reset', itU8, wbBoolEnum).SetDefaultNativeValue(1),
+          wbUnused(3)
+        ]),
+        wbStruct(AI_E, 'AI Escort', [
+          wbVec3('Specific Point'),
+          wbInteger('Duration (Hours)', itU16),
+          wbString(True, 'Target', 32).SetAfterLoad(wbForwardForRealz), //[CREA, NPC_]
+          wbInteger('Reset', itU16, wbBoolEnum).SetDefaultNativeValue(1)
+        ]),
+        wbStruct(AI_F, 'AI Follow', [
+          wbVec3('Specific Point'),
+          wbInteger('Duration (Hours)', itU16),
+          wbString(True, 'Target', 32).SetAfterLoad(wbForwardForRealz), //[CREA, NPC_]
+          wbInteger('Reset', itU16, wbBoolEnum).SetDefaultNativeValue(1)
+        ]),
+        wbStruct(AI_A, 'AI Activate', [
+          wbString(True, 'Target', 32).SetAfterLoad(wbForwardForRealz), //[ACTI, ALCH, APPA, ARMO, BODY, BOOK, CLOT, CONT, CREA, DOOR, ENCH, INGR, LIGH, LEVC, LEVI, LOCK, MISC, NPC_, PROB, REPA, SPEL, STAT, WEAP]
+          wbInteger('Reset', itU8, wbBoolEnum).SetDefaultNativeValue(1)
+        ]),
+        wbString(CNDT, 'Escort/Follow To Cell') //[CELL]
+      ]));
+
+  wbSpells := wbRArrayS('Spells', wbString(NPCS, 'Spell', 32)); //[SPEL]
 
   wbTravelServices :=
     wbRArray('Travel Services',
       wbRStruct('Travel Service', [
-        wbStruct(DODT, 'Destination', [
-          wbVec3('Position'),
-          wbVec3('Rotation')
-        ]).SetRequired,
+        wbVec3PosRot(DODT, 'Destination'),
         wbStringForward(DNAM, 'Cell', 64)
       ]));
 
@@ -504,7 +745,7 @@ begin
 
   wbRecord(TES3, 'Main File Header', [
     wbStruct(HEDR, 'Header', [
-      wbFloat('Version'),
+      wbFloat('Version', cpNormal, False, 1, 2).SetDefaultNativeValue(1.3),
       wbRecordFlags,
       wbString('Author', 32),
       wbString('Description', 256),
@@ -512,44 +753,54 @@ begin
     ]).SetRequired,
     wbRArray('Master Files',
       wbRStruct('Master File', [
-        wbStringForward(MAST, 'Filename').SetRequired,
+        wbStringForward(MAST, 'Master Filename').SetRequired,
         wbInteger(DATA, 'Master Size', itU64, nil, cpIgnore, True)
     ])).IncludeFlag(dfInternalEditOnly, not wbAllowMasterFilesEdit)
   ], False, nil, cpNormal, True)
     .SetGetFormIDCallback(function(const aMainRecord: IwbMainRecord; out aFormID: TwbFormID): Boolean begin
        Result := True;
        aFormID := TwbFormID.Null;
-     end);
+     end)
+     .SetAfterLoad(wbTES3Header);
 
-  wbRecord(ACTI, 'Activator', [
+  wbRecord(ACTI, 'Activator', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
-    wbFNAM,
-    wbSCRI //[SCPT]
+    wbMODL.SetRequired,
+    wbFNAM.SetRequired,
+    wbSCRI
   ]).SetFormIDBase($40);
 
-  wbRecord(ALCH, 'Alchemy', [
+  wbRecord(ALCH, 'Potion', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbMODL,
     wbString(TEXT, 'Icon Filename'),
-    wbSCRI, //[SCPT]
+    wbSCRI,
     wbFNAM,
-    wbStruct(ALDT, 'Alchemy Data', [
+    wbStruct(ALDT, 'Data', [
       wbFloat('Weight', cpNormal, False, 1, 2),
-      wbInteger('Value', itS32),
-      wbInteger('Auto Calculate Value', itU32, wbBoolEnum)
+      wbInteger('Potion Value', itU32),
+      wbInteger('Auto Calculate Value', itU32, wbBoolEnum).SetDefaultNativeValue(True)
     ]).SetRequired,
-    wbENAM
+    wbEffects
   ]).SetFormIDBase($40);
 
-  wbRecord(APPA, 'Apparatus', [
+  wbRecord(APPA, 'Alchemical Apparatus', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
-    wbFNAM,
-    wbSCRI, //[SCPT]
+    wbMODL.SetRequired,
+    wbFNAM.SetRequired,
+    wbSCRI,
     wbStruct(AADT, 'Data', [
       wbInteger('Type', itU32,
         wbEnum([
@@ -557,70 +808,75 @@ begin
           {1} 'Alembic',
           {2} 'Calcinator',
           {3} 'Retort'
-        ])),
-      wbFloat('Quality', cpNormal, False, 1, 2),
-      wbFloat('Weight', cpNormal, False, 1, 2),
-      wbInteger('Value', itS32)
+        ])).SetDefaultNativeValue(1),
+      wbFloat('Quality', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1)
     ]).SetRequired,
-    wbString(ITEX, 'Icon Filename')
+    wbITEX
   ]).SetFormIDBase($40);
 
-  wbRecord(ARMO, 'Armor', [
+  wbRecord(ARMO, 'Armor', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
-    wbFNAM,
-    wbSCRI, //[SCPT]
+    wbMODL.SetRequired,
+    wbFNAM.SetRequired,
+    wbSCRI,
     wbStruct(AODT, 'Data', [
       wbInteger('Type', itU32,
         wbEnum([
-          {0}  'Helmet',
-          {1}  'Cuirass',
-          {2}  'Left Pauldron',
-          {3}  'Right Pauldron',
-          {4}  'Greaves',
-          {5}  'Boots',
-          {6}  'Left Gauntlet',
-          {7}  'Right Gauntlet',
-          {8}  'Shield',
-          {9}  'Left Bracer',
+           {0} 'Helmet',
+           {1} 'Cuirass',
+           {2} 'Left Pauldron',
+           {3} 'Right Pauldron',
+           {4} 'Greaves',
+           {5} 'Boots',
+           {6} 'Left Gauntlet',
+           {7} 'Right Gauntlet',
+           {8} 'Shield',
+           {9} 'Left Bracer',
           {10} 'Right Bracer'
-        ])),
-      wbFloat('Weight', cpNormal, False, 1, 2),
-      wbInteger('Value', itS32),
-      wbInteger('Health', itS32),
-      wbInteger('Enchanting Charge', itS32),
-      wbInteger('Armor Rating', itS32)
+        ])).SetDefaultNativeValue(5),
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbInteger('Health', itU32).SetDefaultNativeValue(100),
+      wbInteger('Enchantment Charge', itU32).SetDefaultNativeValue(100),
+      wbInteger('Armor Rating', itU32).SetDefaultNativeValue(1)
     ]).SetRequired,
-    wbString(ITEX, 'Icon Filename'),
+    wbITEX,
     wbBipedObjects,
-    wbString(ENAM, 'Enchantment') //[ENCH]
+    wbENAM
   ]).SetFormIDBase($40);
 
-  wbRecord(BODY, 'Body Part', @wbKnownSubRecordSignaturesNoFNAM, [
+  wbRecord(BODY, 'Body Part', @wbKnownSubRecordSignaturesNoFNAM, wbFlags(wbFlagsList([
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
-    wbString(FNAM, 'Skin Race'), //[RACE]
+    wbMODL.SetRequired,
+    wbString(FNAM, 'Skin Race').SetDefaultNativeValue('Argonian').SetRequired, //[RACE]
     wbStruct(BYDT, 'Data', [
-      wbInteger('Part', itU8,
+      wbInteger('Body Part', itU8,
         wbEnum([
-          {0} 'Head',
-          {1} 'Hair',
-          {2} 'Neck',
-          {3} 'Chest',
-          {4} 'Groin',
-          {5} 'Hand',
-          {6} 'Wrist',
-          {7} 'Forearm',
-          {8} 'Upperarm',
-          {9} 'Foot',
+           {0} 'Head',
+           {1} 'Hair',
+           {2} 'Neck',
+           {3} 'Chest',
+           {4} 'Groin',
+           {5} 'Hand',
+           {6} 'Wrist',
+           {7} 'Forearm',
+           {8} 'Upperarm',
+           {9} 'Foot',
           {10} 'Ankle',
           {11} 'Knee',
           {12} 'Upperleg',
           {13} 'Clavicle',
           {14} 'Tail'
-        ])),
+        ])).SetDefaultNativeValue(10),
       wbInteger('Skin Type', itU8,
         wbEnum([
           {0} 'Normal',
@@ -630,7 +886,7 @@ begin
         wbFlags([
           {0} 'Female',
           {1} 'Not Playable'
-        ])),
+        ])).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbInteger('Part Type', itU8,
         wbEnum([
           {0} 'Skin',
@@ -638,62 +894,69 @@ begin
           {2} 'Armor'
         ]))
     ]).SetRequired
-  ]).SetFormIDBase($20);
+  ]).SetFormIDBase($20).SetSummaryKey([2]);
 
-  wbRecord(BOOK, 'Book', [
+  wbRecord(BOOK, 'Book', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
-    wbStruct(BKDT, 'Book Data', [
-      wbFloat('Weight', cpNormal, False, 1, 2),
-      wbInteger('Value', itS32),
-      wbInteger('Is Scroll', itU32, wbBoolEnum),
-      wbInteger('Teaches', itS32, wbSkillEnum), //[SKIL]
-      wbInteger('Enchanting Charge', itS32)
+    wbStruct(BKDT, 'Data', [
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbInteger('Scroll', itU32, wbBoolEnum),
+      wbInteger('Teaches', itS32, wbSkillEnum).SetDefaultNativeValue(-1),
+      wbInteger('Enchantment Charge', itU32).SetDefaultNativeValue(100)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename'),
-    wbLStringKC(TEXT, 'Book Text'),
-    wbString(ENAM, 'Enchantment') //[ENCH]
+    wbSCRI,
+    wbITEX,
+    wbStringKC(TEXT, 'Book Text', 0, cpTranslate),
+    wbENAM
   ]).SetFormIDBase($40);
 
   wbRecord(BSGN, 'Birthsign', [
     wbDELE,
     wbNAME,
-    wbFNAM,
-    wbString(TNAM, 'Constellation Image'),
-    wbString(DESC, 'Description'),
-    wbRArray('Spells', wbStringForward(NPCS, 'Spell', 32)) //[SPEL]
+    wbFNAM.SetRequired(False),
+    wbString(TNAM, 'Constellation Filename'),
+    wbDESC,
+    wbSpells
   ]).SetFormIDBase($10);
 
   wbRecord(CELL, 'Cell', [
-    wbNAME,
+    wbString(NAME, 'Location').SetRequired,
     wbDELE,
     wbStruct(DATA, 'Data', [
       wbInteger('Flags', itU32,
         wbFlags(wbSparseFlags([
           0, 'Is Interior Cell',
           1, 'Has Water',
-          2, 'Illegal to Sleep Here',
+          2, 'Illegal To Sleep Here',
           6, 'Has Map Color',
           7, 'Behave Like Exterior'
-        ], False, 8))),
+        ], False, 8))).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbStruct('Grid', [
         wbInteger('X', itS32),
         wbInteger('Y', itS32)
-      ])
+      ]).SetSummaryKey([0, 1])
+        .SetSummaryMemberPrefixSuffix(0, '(', '')
+        .SetSummaryMemberPrefixSuffix(1, '', ')')
+        .SetSummaryDelimiter(', ')
+        .SetDontShow(wbCellInteriorDontShow)
     ]).SetRequired,
-    wbInteger(INTV, 'Water Height (Old Format)', itS32),
+    wbInteger(INTV, 'Water Height', itS32, nil, cpIgnore).SetDontShow(wbCellExteriorDontShow),
     wbString(RGNN, 'Region'),  //[REGN]
-    wbByteColors(NAM5, 'Map Color'),
-    wbFloat(WHGT, 'Water Height'),
+    wbByteColors(NAM5, 'Region Map Color').SetDontShow(wbCellInteriorDontShow),
+    wbFloat(WHGT, 'Water Height').SetDontShow(wbCellExteriorDontShow),
     wbStruct(AMBI, 'Ambience', [
-      wbByteColors('Ambient Color'),
-      wbByteColors('Sunlight Color'),
+      wbByteColors('Ambient Color'), //71, 71, 71, 0 RGBATAG
+      wbByteColors('Sunlight Color'), //242, 217, 217, 0 RGBATAG
       wbByteColors('Fog Color'),
-      wbFloat('Fog Density', cpNormal, False, 1, 2)
-    ])
+      wbFloat('Fog Density', cpNormal, False, 1, 2).SetDefaultNativeValue(1)
+    ]).SetDontShow(wbCellExteriorDontShow)
   ]).SetFormIDBase($B0)
     .SetGetGridCellCallback(function(const aSubRecord: IwbSubRecord; out aGridCell: TwbGridCell): Boolean begin
       with aGridCell, aSubRecord do begin
@@ -706,7 +969,7 @@ begin
     end)
     .SetGetFormIDCallback(function(const aMainRecord: IwbMainRecord; out aFormID: TwbFormID): Boolean begin
       var GridCell: TwbGridCell;
-      Result := aMainRecord.GetGridCell(GridCell) and GridCellToFormID($A0, GridCell, aFormID);
+      Result := aMainRecord.GetGridCell(GridCell) and wbGridCellToFormID($A0, GridCell, aFormID);
     end)
     .SetIdentityCallback(function(const aMainRecord: IwbMainRecord): string begin
       var GridCell: TwbGridCell;
@@ -714,33 +977,34 @@ begin
         Result := '<Exterior>' + GridCell.SortKey
       else
         Result := aMainRecord.EditorID;
-    end);
+    end)
+    .SetAfterLoad(wbCELLAfterLoad);
 
   wbRecord(CLAS, 'Class', [
     wbNAME,
     wbDELE,
-    wbFNAM,
+    wbFNAM.SetRequired,
     wbStruct(CLDT, 'Data', [
-      wbArray('Primary Attributes',
-        wbInteger('Primary Attribute', itS32, wbAttributeEnum),
-      2),
+      wbArray('Primary Attributes', wbInteger('Attribute', itS32, wbAttributeEnum), 2),
       wbInteger('Specialization', itU32, wbSpecializationEnum),
       wbArray('Major & Minor Skill Sets',
         wbStruct('Skill Set', [
-          wbInteger('Minor', itS32, wbSkillEnum), //[SKIL]
-          wbInteger('Major', itS32, wbSkillEnum) //[SKIL]
-        ]),
-      5),
+          wbInteger('Minor Skill', itS32, wbSkillEnum),
+          wbInteger('Major Skill', itS32, wbSkillEnum)
+        ]), 5),
       wbInteger('Playable', itU32, wbBoolEnum),
-      wbInteger('Service Flags', itU32, wbServiceFlags)
+      wbInteger('Buy/Sell Service Flags', itU32, wbServiceFlags).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired,
-    wbString(DESC, 'Description')
+    wbDESC
   ]).SetFormIDBase($18);
 
-  wbRecord(CLOT, 'Clothing', [
+  wbRecord(CLOT, 'Clothing', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(CTDT, 'Data', [
       wbInteger('Type', itU32, wbEnum([
@@ -754,44 +1018,46 @@ begin
         {7} 'Skirt',
         {8} 'Ring',
         {9} 'Amulet'
-      ])),
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itU16),
-      wbInteger('Enchanting Charge', itU16)
+      ])).SetDefaultNativeValue(9),
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU16).SetDefaultNativeValue(1),
+      wbInteger('Enchantment Charge', itU16).SetDefaultNativeValue(100)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename'),
+    wbSCRI,
+    wbITEX,
     wbBipedObjects,
-    wbString(ENAM, 'Enchantment') //[ENCH]
+    wbENAM
   ]).SetFormIDBase($40);
 
-  wbRecord(CONT, 'Container', [
+  wbRecord(CONT, 'Container', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
-    wbFloat(CNDT, 'Weight', cpNormal, False, 1.0, 2),
+    wbFloat(CNDT, 'Weight', cpNormal, False, 1, 2).SetRequired,
     wbInteger(FLAG, 'Flags', itU32,
       wbFlags(wbSparseFlags([
         0, 'Organic',
         1, 'Respawns',
         3, 'Can Hold Items'
-      ], False, 4))),
-    wbSCRI, //[SCPT]
-    wbRArray('Item Entries',
-      wbStruct(NPCO, 'Item Entry', [
-        wbInteger('Count', itS32),
-        wbString('Item', 32) //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LEVI, LIGH, LOCK, MISC, PROB, REPA, WEAP]
-      ]))
+      ], False, 4))).SetDefaultNativeValue(4).IncludeFlag(dfCollapsed, wbCollapseFlags).SetRequired,
+    wbSCRI,
+    wbItems
   ]).SetFormIDBase($40);
 
-  wbRecord(CREA, 'Creature', [
+  wbRecord(CREA, 'Creature', wbFlags(wbFlagsList([
+      10, 'Corpses Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbString(CNAM, 'Sound Generator Creature'), //[CREA]
     wbFNAM,
-    wbSCRI, //[SCPT]
+    wbSCRI,
     wbStruct(NPDT, 'Data', [
       wbInteger('Type', itU32,
         wbEnum([
@@ -800,125 +1066,79 @@ begin
           {2} 'Undead',
           {3} 'Humanoid'
         ])),
-      wbInteger('Level', itS32),
+      wbInteger('Level', itU32).SetDefaultNativeValue(1),
       wbStruct('Attributes', [
-        wbInteger('Strength', itS32),
-        wbInteger('Intelligence', itS32),
-        wbInteger('Willpower', itS32),
-        wbInteger('Agility', itS32),
-        wbInteger('Speed', itS32),
-        wbInteger('Endurance', itS32),
-        wbInteger('Personality', itS32),
-        wbInteger('Luck', itS32)
+        wbInteger('Strength', itU32).SetDefaultNativeValue(50),
+        wbInteger('Intelligence', itU32).SetDefaultNativeValue(50),
+        wbInteger('Willpower', itU32).SetDefaultNativeValue(50),
+        wbInteger('Agility', itU32).SetDefaultNativeValue(50),
+        wbInteger('Speed', itU32).SetDefaultNativeValue(50),
+        wbInteger('Endurance', itU32).SetDefaultNativeValue(50),
+        wbInteger('Personality', itU32).SetDefaultNativeValue(50),
+        wbInteger('Luck', itU32).SetDefaultNativeValue(50)
       ]),
-      wbInteger('Health', itS32),
-      wbInteger('Magicka', itS32),
-      wbInteger('Fatigue', itS32),
-      wbInteger('Soul', itU32),
+      wbInteger('Health', itU32).SetDefaultNativeValue(50),
+      wbInteger('Magicka', itU32).SetDefaultNativeValue(50),
+      wbInteger('Fatigue', itU32).SetDefaultNativeValue(50),
+      wbInteger('Soul', itU32).SetDefaultNativeValue(50),
       wbStruct('Skills', [
-        wbInteger('Combat', itS32),
-        wbInteger('Magic', itS32),
-        wbInteger('Stealth', itS32)
+        wbInteger('Combat', itU32).SetDefaultNativeValue(50),
+        wbInteger('Magic', itU32).SetDefaultNativeValue(50),
+        wbInteger('Stealth', itU32).SetDefaultNativeValue(50)
       ]),
       wbArray('Attack Sets',
         wbStruct('Attack Set', [
-          wbInteger('Minimum', itS32),
-          wbInteger('Maximum', itS32)
-        ]),
-      3),
+          wbInteger('Minimum', itU32).SetDefaultNativeValue(1),
+          wbInteger('Maximum', itU32).SetDefaultNativeValue(5)
+        ]), 3),
       wbInteger('Barter Gold', itU32)
     ]).SetRequired,
     wbInteger(FLAG, 'Flags', itU32,
       wbFlags(wbSparseFlags([
-        0, 'Biped',
-        1, 'Respawn',
-        2, 'Weapon & Shield',
-        3, 'Can Hold Items',
-        4, 'Swims',
-        5, 'Flies',
-        6, 'Walks',
-        7, 'Essential',
+         0, 'Biped',
+         1, 'Respawn',
+         2, 'Weapon & Shield',
+         3, 'Can Hold Items',
+         4, 'Swims',
+         5, 'Flies',
+         6, 'Walks',
+         7, 'Essential',
         10, 'Skeleton Blood',
         11, 'Metal Blood'
-      ], False, 12))
-    ).IncludeFlag(dfCollapsed, wbCollapseFlags),
-    wbFloat(XSCL, 'Scale', cpNormal, False, 1.0, 2),
-    wbRArray('Item Entries',
-      wbStruct(NPCO, 'Item Entry', [
-        wbInteger('Count', itS32),
-        wbString('Item', 32) //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LEVI, LIGH, LOCK, MISC, PROB, REPA, WEAP]
-      ])),
-    wbRArray('Spells', wbString(NPCS, 'Spell', 32)), //[SPEL]
+      ], False, 12))).SetDefaultNativeValue(48).IncludeFlag(dfCollapsed, wbCollapseFlags).SetRequired,
+    wbFloat(XSCL, 'Scale', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+    wbItems,
+    wbSpells,
     wbAIDT,
     wbTravelServices,
-    wbRArray('AI Packages',
-      wbRUnion('AI Packages', [
-        wbStruct(AI_T, 'AI Travel', [
-          wbVec3('Position'),
-          wbInteger('Reset', itU8, wbBoolEnum),
-          wbUnused(3)
-        ]).SetRequired,
-        wbStruct(AI_W, 'AI Wander', [
-          wbInteger('Distance', itU16),
-          wbInteger('Duration In Hours', itU16),
-          wbInteger('Time of Day', itU8),
-          wbStruct('Idle Chances', [
-            wbInteger('Idle 2', itU8),
-            wbInteger('Idle 3', itU8),
-            wbInteger('Idle 4', itU8),
-            wbInteger('Idle 5', itU8),
-            wbInteger('Idle 6', itU8),
-            wbInteger('Idle 7', itU8),
-            wbInteger('Idle 8', itU8),
-            wbInteger('Idle 9', itU8)
-          ]),
-          wbInteger('Reset', itU8, wbBoolEnum)
-        ]).SetRequired,
-        wbRStruct('AI Escort', [
-          wbStruct(AI_E, 'AI Escort', [
-            wbVec3('Position'),
-            wbInteger('Duration In Hours', itU16),
-            wbString(True, 'Target', 32), //[CREA, NPC_]
-            wbInteger('Reset', itU16, wbBoolEnum)
-          ]).SetRequired,
-          wbString(CNDT, 'Escort To Cell') //[CELL]
-        ]),
-        wbRStruct('AI Follow', [
-          wbStruct(AI_F, 'AI Follow', [
-            wbVec3('Position'),
-            wbInteger('Duration In Hours', itU16),
-            wbString(True, 'Target', 32), //[CREA, NPC_]
-            wbInteger('Reset', itU16, wbBoolEnum)
-          ]).SetRequired,
-          wbString(CNDT, 'Follow To Cell') //[CELL]
-        ]),
-        wbStruct(AI_A, 'AI Activate', [
-          wbString(True, 'Target', 32), //[ACTI, ALCH, APPA, ARMO, BODY, BOOK, CLOT, CONT, CREA, DOOR, ENCH, INGR, LIGH, LEVC, LEVI, LOCK, MISC, NPC_, PROB, REPA, SPEL, STAT, WEAP]
-          wbInteger('Reset', itU8, wbBoolEnum)
-        ]).SetRequired
-      ]))
+    wbPackages
   ]).SetFormIDBase($40);
 
   wbRecord(DIAL, 'Dialog Topic', [
     wbNAME,
-    wbStruct(DATA, 'Data', [
+    wbUnion(DATA, 'Data', wbDialogDataDecider, [
       wbInteger('Dialog Type', itU8, wbDialogTypeEnum),
-      wbUnused(3)
-    ]),
+      wbInteger('Dialog Type', itU32, wbDialogTypeEnum)
+    ]).SetRequired,
     wbDELE
-  ]).SetFormIDBase($80);
+  ]).SetFormIDBase($80).SetSummaryKey([1]);
 
-  wbRecord(DOOR, 'Door', [
+  wbRecord(DOOR, 'Door', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbMODL,
-    wbFNAM,
-    wbSCRI, //[SCPT]
+    wbFNAM.SetRequired(False),
+    wbSCRI,
     wbString(SNAM, 'Open Sound'), //[SOUN]
     wbString(ANAM, 'Close Sound') //[SOUN]
   ]).SetFormIDBase($40);
 
-  wbRecord(ENCH, 'Enchantment', [
+  wbRecord(ENCH, 'Enchantment', wbFlags(wbFlagsList([
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbStruct(ENDT, 'Data', [
@@ -929,51 +1149,54 @@ begin
           {2} 'Cast When Used',
           {3} 'Constant Effect'
         ])),
-      wbInteger('Enchantment Cost', itS32),
-      wbInteger('Charge Amount', itS32),
-      wbInteger('Auto Calculate', itU32,
+      wbInteger('Enchantment Cost', itU32),
+      wbInteger('Charge Amount', itU32),
+      wbInteger('Auto Calculate', itS16,
         wbEnum([
           {0} 'False',
           {1} 'True'
         ], [
-          $0000FFFE, 'N/A - Constant Effect'
-      ]))
+          -2, 'Constant Effect',
+          -1, 'Not Applicable'
+        ])),
+      wbUnused(2)
     ]).SetRequired,
-    wbENAM
-  ]).SetFormIDBase($04);
+    wbEffects
+  ]).SetFormIDBase($04).SetSummaryKey([3]);
 
   wbRecord(FACT, 'Faction', [
     wbNAME,
     wbDELE,
-    wbString(FNAM, 'Name'),
-    wbRArray('Ranks', wbStringForward(RNAM, 'Rank', 32)),
+    wbFNAM.SetRequired,
+    wbRArray('Rank Titles', wbStringForward(RNAM, 'Rank Title', 32)),
     wbStruct(FADT, 'Data', [
-      wbArray('Attributes',
-        wbInteger('Attribute', itS32, wbAttributeEnum),
-      2),
-      wbArray('Ranks',
-        wbStruct('Rank', [
-          wbArray('Attribute Values',
-            wbInteger('Attribute Value', itU32),
-          2),
-          wbInteger('Primary Skills Value', itU32),
-          wbInteger('Favored Skills Value', itU32),
+      wbArray('Favored Attributes', wbInteger('Attribute', itS32, wbAttributeEnum), 2),
+      wbArray('Rank Requirements',
+        wbStruct('Rank Requirement', [
+          wbInteger('Favored Attribute 1', itS32),
+          wbInteger('Favored Attribute 2', itS32),
+          wbInteger('Primary Skills', itS32),
+          wbInteger('Favored Skills', itS32),
           wbInteger('Faction Reputation', itU32)
-        ]),
-      10),
-      wbArray('Favored Skills',
-        wbInteger('Skill', itS32, wbSkillEnum),
-      7),
+        ]).SetSummaryKey([0, 1, 2, 3, 4])
+          .SetSummaryMemberPrefixSuffix(0, 'Attribute 0:', ',')
+          .SetSummaryMemberPrefixSuffix(1, 'Attribute 2:', ',')
+          .SetSummaryMemberPrefixSuffix(2, 'Primary Skills:', ',')
+          .SetSummaryMemberPrefixSuffix(3, 'Favored Skills:', ',')
+          .SetSummaryMemberPrefixSuffix(4, 'Faction Reputation:', '')
+          .IncludeFlag(dfSummaryMembersNoName)
+          .IncludeFlag(dfCollapsed), 10),
+      wbArray('Favored Skills', wbInteger('Favored Skill', itS32, wbSkillEnum), 7),
       wbInteger('Hidden From Player', itU32, wbBoolEnum)
     ]).SetRequired,
-    wbRArray('Relations',
-      wbRStructSK([], 'Relation', [
+    wbRArrayS('Relations',
+      wbRStructSK([0], 'Relation', [
         wbString(ANAM, 'Faction'), //[FACT]
         wbInteger(INTV, 'Reaction', itS32)
-      ]))
+      ]).SetToStr(wbFactionReactionToStr))
   ]).SetFormIDBase($1C);
 
-  wbRecord(GLOB, 'Global', @wbKnownSubRecordSignaturesNoFNAM,  [
+  wbRecord(GLOB, 'Global', @wbKnownSubRecordSignaturesNoFNAM, [
     wbNAME,
     wbDELE,
     wbInteger(FNAM, 'Variable Type', itU8,
@@ -981,164 +1204,171 @@ begin
         $66, 'Float',
         $6C, 'Long',
         $73, 'Short'
-      ])),
-    wbUnion(FLTV, 'Value', wbGLOBUnionDecider, [
-      wbFloat('Value - Short'),
-      wbFloat('Value - Long'),
-      wbFloat('Value - Float')
-    ])
-  ]).SetFormIDBase($58);
+      ])).SetDefaultNativeValue($73),
+    wbFloat(FLTV, 'Value', cpNormal, False, 1, 2)
+  ]).SetFormIDBase($58).SetSummaryKey([3]).SetAfterLoad(wbGlobalAfterLoad);
 
   wbRecord(GMST, 'Game Setting', [
     wbNAME,
     wbRUnion('Value', [
-      wbString(STRV, 'Value - String'),
-      wbInteger(INTV, 'Value - Signed Integer', itS32),
-      wbFloat(FLTV, 'Value - Float')
+      wbString(STRV, 'String Value'),
+      wbInteger(INTV, 'Integer Value', itS32),
+      wbFloat(FLTV, 'Float Value', cpNormal, False, 1, 4)
     ])
-  ]).SetFormIDBase($50)
-    .IncludeFlag(dfIndexEditorID);
+  ]).SetFormIDBase($50).SetSummaryKey([1]).IncludeFlag(dfIndexEditorID);
 
   wbRecord(INFO, 'Dialog Response', @wbKnownSubRecordSignaturesINFO, [
-    wbString(INAM, 'Response ID'),
-    wbString(PNAM, 'Previous Response ID'),
-    wbString(NNAM, 'Next Response ID'),
+    wbString(INAM, 'Response ID').SetRequired,
+    wbString(PNAM, 'Previous Response ID').SetRequired,
+    wbString(NNAM, 'Next Response ID').SetRequired,
     wbStruct(DATA, 'Data', [
       wbInteger('Dialog Type', itU32, wbDialogTypeEnum),
       wbInteger('Disposition/Index', itU32),
-      wbInteger('Speaker Faction Rank', itS8),
-      wbInteger('Gender', itS8, wbSexEnum),
-      wbInteger('Player Faction Rank', itS8),
+      wbInteger('Speaker Faction Rank', itS8).SetDefaultNativeValue(-1),
+      wbInteger('Sex', itS8, wbSexEnum).SetDefaultNativeValue(-1),
+      wbInteger('Player Faction Rank', itS8).SetDefaultNativeValue(-1),
       wbUnused(1)
     ]).SetRequired,
-    wbString(ONAM, 'Speaker'), //[NPC_]
+    wbString(ONAM, 'Speaker'), //[CREA, NPC_]
     wbString(RNAM, 'Speaker Race'), //[RACE]
     wbString(CNAM, 'Speaker Class'), //[CLAS]
-    wbString(FNAM, 'Speaker In Faction'), //[FACT]
-    wbString(ANAM, 'Speaker In Cell'), //[CELL]
+    wbString(FNAM, 'Speaker Faction'), //[FACT]
+    wbString(ANAM, 'Speaker Cell'), //[CELL]
     wbString(DNAM, 'Player Faction'), //[FACT]
     wbString(SNAM, 'Sound Filename'),
     wbString(NAME, 'Response'),
     wbDELE,
-    wbRStruct('Quest Data', [
-      wbInteger(QSTN, 'Quest Name', itU8,
-        wbEnum([], [1, 'Quest Name'])
-      ).SetDefaultNativeValue(1),
-      wbInteger(QSTF, 'Quest Finished', itU8,
-        wbEnum([], [1, 'Quest Finished'])
-      ).SetDefaultNativeValue(1),
-      wbInteger(QSTR, 'Quest Restarted', itU8,
-        wbEnum([], [1, 'Quest Restarted'])
-      ).SetDefaultNativeValue(1)
-    ], [], cpNormal, False, nil, True),
     wbRArray('Conditions',
-      wbRStructSK([], 'Condition', [
-        wbStruct(SCVR, 'Condition Breakdown', [
+      wbRStruct('Condition', [
+        wbStruct(SCVR, 'Condition', [
           wbInteger('Position', itU8,
             wbEnum([], [
-              $30, '1st', //0
-              $31, '2nd', //1
-              $32, '3rd', //2
-              $33, '4th', //3
-              $34, '5th', //4
-              $35, '6th' //5
+              $30, '1st',
+              $31, '2nd',
+              $32, '3rd',
+              $33, '4th',
+              $34, '5th',
+              $35, '6th'
             ])),
-          wbInteger('Function', itU24,
+          wbInteger('Type', itU8,
             wbEnum([], [
-              $313030, 'Reaction Low', //100
-              $313031, 'Reaction High', //101
-              $313032, 'Rank Requirement', //102
-              $313033, 'Reputation', //103
-              $313034, 'Health Percent', //104
-              $313035, 'PC Reputation', //105
-              $313036, 'PC Level', //106
-              $313037, 'PC Health Percent', //107
-              $313038, 'PC Magicka', //108
-              $313039, 'PC Fatigue', //109
-              $313130, 'PC Strength', //110
-              $313131, 'PC Block', //111
-              $313132, 'PC Armorer', //112
-              $313133, 'PC Medium Armor', //113
-              $313134, 'PC Heavy Armor', //114
-              $313135, 'PC Blunt Weapon', //115
-              $313136, 'PC Long Blade', //116
-              $313137, 'PC Axe', //117
-              $313138, 'PC Spear', //118
-              $313139, 'PC Athletics', //119
-              $313230, 'PC Enchant', //120
-              $313231, 'PC Destruction', //121
-              $313232, 'PC Alteration', //122
-              $313233, 'PC Illusion', //123
-              $313234, 'PC Conjuration', //124
-              $313235, 'PC Mysticism', //125
-              $313236, 'PC Restoration', //126
-              $313237, 'PC Alchemy', //127
-              $313238, 'PC Unarmored', //128
-              $313239, 'PC Security', //129
-              $313330, 'PC Sneak', //130
-              $313331, 'PC Acrobatics', //131
-              $313332, 'PC Light Armor', //132
-              $313333, 'PC Short Blade', //133
-              $313334, 'PC Marksman', //134
-              $313335, 'PC Mercantile', //135
-              $313336, 'PC Speechcraft', //136
-              $313337, 'PC Hand To Hand', //137
-              $313338, 'PC Sex', //138
-              $313339, 'PC Expelled', //139
-              $313430, 'PC Common Disease', //140
-              $313431, 'PC Blight Disease', //141
-              $313432, 'Clothing Modifier', //142
-              $313433, 'PC Crime Level', //143
-              $313434, 'Same Sex', //144
-              $313435, 'Same Race', //145
-              $313436, 'Same Faction', //146
-              $313437, 'Faction Rank Difference', //147
-              $313438, 'Detected', //148
-              $313439, 'Alarmed', //149
-              $313530, 'Choice', //150
-              $313531, 'PC Intelligence', //151
-              $313532, 'PC Willpower', //152
-              $313533, 'PC Agility', //153
-              $313534, 'PC Speed', //154
-              $313535, 'PC Endurance', //155
-              $313536, 'PC Personality', //156
-              $313537, 'PC Luck', //157
-              $313538, 'PC Corpus', //158
-              $313539, 'Weather', //159
-              $313630, 'PC Vampire', //160
-              $313631, 'Level', //161
-              $313632, 'Attacked', //162
-              $313633, 'Talked To PC', //163
-              $313634, 'PC Health', //164
-              $313635, 'Creature Target', //165
-              $313636, 'Friend Hit', //166
-              $313637, 'Fight', //167
-              $313638, 'Hello', //168
-              $313639, 'Alarm', //169
-              $313730, 'Flee', //170
-              $313731, 'Should Attack', //171
-              $313732, 'Werewolf', //172
-              $313733, 'PC Werewolf Kills', //173
-              $327358, 'Global', //2sX //[GLOB]
-              $337358, 'Local', //3sX
-              $344A58, 'Journal', //4JX //[DIAL]
-              $354958, 'Item', //5IX //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LIGH, LOCK, MISC, PROB, REPA, WEAP]
-              $364458, 'Dead', //6DX //[CREA, NPC_]
-              $375858, 'Not ID', //7XX //[NPC_]
-              $384658, 'Not Faction', //8FX //[FACT]
-              $394358, 'Not Class', //9CX //[CLAS]
-              $415258, 'Not Race', //ARX //[RACE]
-              $424C58, 'Not Cell', //BLX //[CELL]
-              $437358, 'Not Local' //CsX),
+              $31, 'Function',
+              $32, 'Global', //[GLOB]
+              $33, 'Script Variable',
+              $34, 'Journal',
+              $35, 'Item',
+              $36, 'Dead',
+              $37, 'Not ID',
+              $38, 'Not Faction',
+              $39, 'Not Class',
+              $41, 'Not Race',
+              $42, 'Not Cell',
+              $43, 'Not Script Variable'
             ])),
+          wbUnion('Function', wbConditionDecider, [
+            wbInteger('Function', itU16,
+              wbEnum([], [
+                $3030, 'Reaction Low',
+                $3031, 'PC Strength',
+                $3032, 'PC Enchant',
+                $3033, 'PC Sneak',
+                $3034, 'PC Common Disease',
+                $3035, 'Choice',
+                $3036, 'PC Vampire',
+                $3037, 'Flee',
+                $3130, 'Reaction High',
+                $3131, 'PC Block',
+                $3132, 'PC Destruction',
+                $3133, 'PC Acrobatics',
+                $3134, 'PC Blight Disease',
+                $3135, 'PC Intelligence',
+                $3136, 'Level',
+                $3137, 'Should Attack',
+                $3230, 'Rank Requirement',
+                $3231, 'PC Armorer',
+                $3232, 'PC Alteration',
+                $3233, 'PC Light Armor',
+                $3234, 'Clothing Modifier',
+                $3235, 'PC Willpower',
+                $3236, 'Attacked',
+                $3237, 'Werewolf',
+                $3330, 'Reputation',
+                $3331, 'PC Medium Armor',
+                $3332, 'PC Illusion',
+                $3333, 'PC Short Blade',
+                $3334, 'PC Crime Level',
+                $3335, 'PC Agility',
+                $3336, 'Talked To PC',
+                $3337, 'PC Werewolf Kills',
+                $3430, 'Health Percent',
+                $3431, 'PC Heavy Armor',
+                $3432, 'PC Conjuration',
+                $3433, 'PC Marksman',
+                $3434, 'Same Sex',
+                $3435, 'PC Speed',
+                $3436, 'PC Health',
+                $3530, 'PC Reputation',
+                $3531, 'PC Blunt Weapon',
+                $3532, 'PC Mysticism',
+                $3533, 'PC Mercantile',
+                $3534, 'Same Race',
+                $3535, 'PC Endurance',
+                $3536, 'Creature Target',
+                $3630, 'PC Level',
+                $3631, 'PC Long Blade',
+                $3632, 'PC Restoration',
+                $3633, 'PC Speechcraft',
+                $3634, 'Same Faction',
+                $3635, 'PC Personality',
+                $3636, 'Friend Hit',
+                $3730, 'PC Health Percent',
+                $3731, 'PC Axe',
+                $3732, 'PC Alchemy',
+                $3733, 'PC Hand To Hand',
+                $3734, 'Faction Rank Difference',
+                $3735, 'PC Luck',
+                $3736, 'Fight',
+                $3830, 'PC Magicka',
+                $3831, 'PC Spear',
+                $3832, 'PC Unarmored',
+                $3833, 'PC Sex',
+                $3834, 'Detected',
+                $3835, 'PC Corpus',
+                $3836, 'Hello',
+                $3930, 'PC Fatigue',
+                $3931, 'PC Athletics',
+                $3932, 'PC Security',
+                $3933, 'PC Expelled',
+                $3934, 'Alarmed',
+                $3935, 'Weather',
+                $3936, 'Alarm'
+              ])),
+            wbInteger('Variable Type', itU16,
+              wbEnum([], [
+                $5866, 'Float',
+                $586C, 'Long',
+                $5873, 'Short'
+              ])),
+            wbInteger('Object Type', itU16,
+              wbEnum([], [
+                $5843, 'Class', //[CLAS]
+                $5844, 'Actor', //[CREA, NPC_]
+                $5846, 'Faction', //[FACT]
+                $5849, 'Inventory Item', //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LIGH, LOCK, MISC, PROB, REPA, WEAP]
+                $584A, 'Dialog Topic', //DIAL
+                $584C, 'Cell', //[CELL]
+                $5852, 'Race', //[RACE]
+                $5858, 'Non-Player Character' //[NPC_]
+              ]))
+            ]),
           wbInteger('Operator', itU8,
             wbEnum([], [
-              $30, 'Equal To', //0
-              $31, 'Not Equal To', //1
-              $32, 'Less Than', //2
-              $33, 'Less Than or Equal To', //3
-              $34, 'Greater Than', //4
-              $35, 'Greater Than or Equal To' //5
+              $30, 'Equal To',
+              $31, 'Not Equal To',
+              $32, 'Less Than',
+              $33, 'Less Than or Equal To',
+              $34, 'Greater Than',
+              $35, 'Greater Than or Equal To'
             ])),
           wbString('Variable/Object')
         ]),
@@ -1147,141 +1377,98 @@ begin
           wbFloat(FLTV, 'Value')
         ])
       ])),
+    wbRStruct('Quest Data', [
+      wbInteger(QSTN, 'Quest Named', itU8, wbBoolEnum).SetDefaultNativeValue(1),
+      wbInteger(QSTF, 'Quest Finished', itU8, wbBoolEnum).SetDefaultNativeValue(1),
+      wbInteger(QSTR, 'Quest Restarted', itU8, wbBoolEnum).SetDefaultNativeValue(1)
+    ], [], cpNormal, False, nil, True),
     wbString(BNAM, 'Result')
   ]).SetFormIDBase($90);
 
-  wbRecord(INGR, 'Ingredient', [
+  wbRecord(INGR, 'Ingredient', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(IRDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
       wbStruct('Effects', [
-        wbArray('Magic Effects',
-          wbInteger('Magic Effect', itS32, wbMagicEffectEnum),
-        4),
-        wbArray('Skills',
-          wbInteger('Skill', itS32,
-            wbEnum([
-              {0}  'Block (None for Attribute based Magic Effects)',
-              {1}  'Armorer',
-              {2}  'Medium Armor',
-              {3}  'Heavy Armor',
-              {4}  'Blunt Weapon',
-              {5}  'Long Blade',
-              {6}  'Axe',
-              {7}  'Spear',
-              {8}  'Athletics',
-              {9}  'Enchant',
-              {10} 'Destruction',
-              {11} 'Alteration',
-              {12} 'Illusion',
-              {13} 'Conjuration',
-              {14} 'Mysticism',
-              {15} 'Restoration',
-              {16} 'Alchemy',
-              {17} 'Unarmored',
-              {18} 'Security',
-              {19} 'Sneak',
-              {20} 'Acrobatics',
-              {21} 'Light Armor',
-              {22} 'Short Blade',
-              {23} 'Marksman',
-              {24} 'Mercantile',
-              {25} 'Speechcraft',
-              {26} 'Hand-To-Hand'
-            ], [
-              -1, 'None'
-            ])),
-        4),
-        wbArray('Attributes',
-          wbInteger('Attribute', itS32,
-            wbEnum([
-              {0} 'Strength (None for Skill based Magic Effects)',
-              {1} 'Intelligence',
-              {2} 'Willpower',
-              {3} 'Agility',
-              {4} 'Speed',
-              {5} 'Endurance',
-              {6} 'Personality',
-              {7} 'Luck'
-            ], [
-              -1, 'None'
-            ])),
-        4)
+        wbArray('Magic Effects', wbInteger('Magic Effect', itS32, wbMagicEffectEnum).SetDefaultNativeValue(-1), 4),
+        wbArray('Skills', wbInteger('Skill', itS32, wbSkillEnum).SetDefaultNativeValue(-1), 4),
+        wbArray('Attributes', wbInteger('Attribute', itS32, wbAttributeEnum).SetDefaultNativeValue(-1), 4)
       ])
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename')
-  ]).SetFormIDBase($40);
+    wbSCRI,
+    wbITEX
+  ]).SetFormIDBase($40).SetAfterLoad(wbINGRAfterLoad);
 
   wbRecord(LAND, 'Landscape', @wbKnownSubRecordSignaturesLAND, [
     wbStruct(INTV, 'Grid', [
       wbInteger('X', itS32),
       wbInteger('Y', itS32)
-    ], cpCritical).SetRequired,
+    ], cpCritical).SetSummaryKeyOnValue([0, 1])
+                  .SetSummaryPrefixSuffixOnValue(0, '(', '')
+                  .SetSummaryPrefixSuffixOnValue(1, '', ')')
+                  .SetSummaryDelimiterOnValue(', ')
+                  .SetRequired,
     wbInteger(DATA, 'Flags', itU32,
       wbFlags([
         {0} 'Has Vertex Normals/Height Map',
         {1} 'Has Vertex Colors',
         {2} 'Has Landscape Textures',
         {3} 'User Created/Edited'
-      ])),
+      ])).SetDefaultNativeValue(8).IncludeFlag(dfCollapsed, wbCollapseFlags),
     IfThen(wbSimpleRecords,
       wbByteArray(VNML, 'Vertex Normals'),
       wbArray(VNML, 'Vertex Normals',
         wbArray('Row',
           wbStruct('Column', [
-            wbInteger('X', itS8),
-            wbInteger('Y', itS8),
-            wbInteger('Z', itS8)
-          ]),
-        65),
-      65)),
+            wbInteger('X', itS8, nil, cpBenign, False, nil, nil, 0, wbLandNormalsGetCP),
+            wbInteger('Y', itS8, nil, cpBenign, False, nil, nil, 0, wbLandNormalsGetCP),
+            wbInteger('Z', itS8, nil, cpBenign, False, nil, nil, 0, wbLandNormalsGetCP)
+          ]).SetSummaryKey([0, 1, 2])
+            .SetSummaryMemberPrefixSuffix(0, '' + '(', '')
+            .SetSummaryMemberPrefixSuffix(2, '', ')')
+            .IncludeFlag(dfSummaryMembersNoName)
+            .IncludeFlag(dfCollapsed, wbCollapseVec3),
+        65).SetSummaryName('Columns').IncludeFlag(dfCollapsed),
+      65).SetSummaryName('Rows').IncludeFlag(dfCollapsed)),
     IfThen(wbSimpleRecords,
       wbByteArray(VHGT, 'Vertex Height Map'),
       wbStruct(VHGT, 'Vertex Height Map', [
         wbFloat('Offset'),
         wbUnused(1),
-        wbArray('Height Map',
-          wbArray('Row',
-            wbInteger('Column', itS8),
-          65),
-        65),
+        wbArray('Height Map', wbArray('Row', wbInteger('Column', itS8),
+          65).SetSummaryName('Columns').IncludeFlag(dfCollapsed),
+        65).SetSummaryName('Rows').IncludeFlag(dfCollapsed),
         wbUnused(2)
       ])),
     IfThen(wbSimpleRecords,
-      wbByteArray(WNAM, 'World Map Painting'),
-      wbArray(WNAM, 'World Map Painting',
-        wbArray('Row',
-          wbInteger('Column', itS8),
-        9),
-      9)),
+      wbByteArray(WNAM, 'World Map Colors'),
+      wbArray(WNAM, 'World Map Colors',
+        wbArray('Row', wbInteger('Column', itS8),
+        9).SetSummaryName('Columns').IncludeFlag(dfCollapsed),
+      9).SetSummaryName('Rows').IncludeFlag(dfCollapsed)),
     IfThen(wbSimpleRecords,
       wbByteArray(VCLR, 'Vertex Colors'),
       wbArray(VCLR, 'Vertex Colors',
-        wbArray('Row',
-          wbStruct('Column', [
-            wbInteger('Red', itU8),
-            wbInteger('Green', itU8),
-            wbInteger('Blue', itU8)
-          ]),
-        65),
-      65)),
+        wbArray('Row', wbByteColorsRGB('Column').SetToStr(wbRGBAToStr).IncludeFlag(dfCollapsed, wbCollapseVec3),
+        65).SetSummaryName('Columns').IncludeFlag(dfCollapsed),
+      65).SetSummaryName('Rows').IncludeFlag(dfCollapsed)),
     IfThen(wbSimpleRecords,
-      wbByteArray(VTXT, 'Textures'),
-      wbArray(VTEX, 'Textures',
-        wbArray('Row',
-          wbInteger('Column', itU16), //[LTEX]
-        16),
-      16))
+      wbByteArray(VTEX, 'Landscape Textures'),
+      wbArray(VTEX, 'Landscape Textures', wbArray('Row', wbInteger('Column', itU16),
+        16).SetSummaryName('Columns').IncludeFlag(dfCollapsed),
+      16).SetSummaryName('Rows').IncludeFlag(dfCollapsed))
   ]).SetFormIDBase($D0)
     .SetFormIDNameBase($B0)
     .SetGetFormIDCallback(function(const aMainRecord: IwbMainRecord; out aFormID: TwbFormID): Boolean begin
       var GridCell: TwbGridCell;
-      Result := aMainRecord.GetGridCell(GridCell) and GridCellToFormID($C0, GridCell, aFormID);
+      Result := aMainRecord.GetGridCell(GridCell) and wbGridCellToFormID($C0, GridCell, aFormID);
     end)
     .SetIdentityCallback(function(const aMainRecord: IwbMainRecord): string begin
       Result := '';
@@ -1290,44 +1477,63 @@ begin
         Result := GridCell.SortKey
     end);
 
-  wbRecord(LEVC, 'Leveled Creature', [
+  wbRecord(LEVC, 'Leveled Creature', wbFlags(wbFlagsList([
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbInteger(DATA, 'Leveled Flags', itU32, wbLeveledFlags),
-    wbInteger(NNAM, 'Chance None', itU8),
+    wbInteger(DATA, 'Flags', itU32, wbLeveledFlags).IncludeFlag(dfCollapsed, wbCollapseFlags).SetRequired,
+    wbInteger(NNAM, 'Chance None %', itU8).SetRequired,
     wbInteger(INDX, 'Entry Count', itU32),
-    wbRArray('Leveled Creature Entries',
-      wbRStruct('Leveled Creature Entry', [
+    wbRArrayS('Leveled Creature Entries',
+      wbRStructSK([1], 'Leveled Creature Entry', [
         wbString(CNAM, 'Creature'), //[CREA]
         wbInteger(INTV, 'Player Level', itU16)
-      ]))
-  ]).SetFormIDBase($40);
+      ]).SetSummaryKey([1, 0])
+        .SetSummaryMemberPrefixSuffix(1, '[Level: ', ']')
+        .SetSummaryMemberPrefixSuffix(0, '', ' x1')
+        .IncludeFlag(dfSummaryMembersNoName)
+        .IncludeFlag(dfSummaryNoSortKey)
+        .IncludeFlag(dfCollapsed, wbCollapseLeveledItems)
+    ).SetCountPath(INDX)
+  ]).SetFormIDBase($40).SetSummaryKey([5]);
 
-  wbRecord(LEVI, 'Leveled Item', [
+  wbRecord(LEVI, 'Leveled Item', wbFlags(wbFlagsList([
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbInteger(DATA, 'Levelved Flags', itU32, wbLeveledFlags),
-    wbInteger(NNAM, 'Chance None', itU8),
+    wbInteger(DATA, 'Flags', itU32, wbLeveledFlags).IncludeFlag(dfCollapsed, wbCollapseFlags).SetRequired,
+    wbInteger(NNAM, 'Chance None %', itU8).SetRequired,
     wbInteger(INDX, 'Entry Count', itU32),
-    wbRArray('Leveled Item Entries',
-      wbRStruct('Leveled Item Entry', [
+    wbRArrayS('Leveled Item Entries',
+      wbRStructSK([1], 'Leveled Item Entry', [
         wbString(INAM, 'Item'), //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LEVI, LIGH, LOCK, MISC, PROB, REPA, WEAP]
         wbInteger(INTV, 'Player Level', itU16)
-      ]))
-  ]).SetFormIDBase($40);
+      ]).SetSummaryKey([1, 0])
+        .SetSummaryMemberPrefixSuffix(1, '[Level: ', ']')
+        .SetSummaryMemberPrefixSuffix(0, '', ' x1')
+        .IncludeFlag(dfSummaryMembersNoName)
+        .IncludeFlag(dfSummaryNoSortKey)
+        .IncludeFlag(dfCollapsed, wbCollapseLeveledItems)
+    ).SetCountPath(INDX)
+  ]).SetFormIDBase($40).SetSummaryKey([5]);
 
-  wbRecord(LIGH, 'Light', [
+  wbRecord(LIGH, 'Light', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
-    wbString(ITEX, 'Icon Filename'),
+    wbITEX,
     wbStruct(LHDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
-      wbInteger('Time', itS32),
-      wbFloat('Radius', cpNormal, False, 1.0, 2),
-      wbByteColors,
+      wbFloat('Weight', cpNormal, False, 1, 2),
+      wbInteger('Value', itU32),
+      wbInteger('Time', itS32).SetDefaultNativeValue(-1),
+      wbInteger('Radius', itU32).SetDefaultNativeValue(1000),
+      wbByteColors, //255, 255, 255, 0 RGBATAG
       wbInteger('Flags', itU32,
         wbFlags([
           {0} 'Dynamic',
@@ -1341,31 +1547,34 @@ begin
           {8} 'Pulse Slow'
         ])).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(SNAM, 'Sound') //[SOUN]
+    wbSCRI,
+    wbString(SNAM, 'Looping Sound') //[SOUN]
   ]).SetFormIDBase($40);
 
-  wbRecord(LOCK, 'Lockpick', [
+  wbRecord(LOCK, 'Lockpick', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbMODL,
-    wbFNAM,
+    wbFNAM.SetRequired,
     wbStruct(LKDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
-      wbFloat('Quality', cpNormal, False, 1.0, 2),
-      wbInteger('Uses', itS32)
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbFloat('Quality', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Uses', itU32).SetDefaultNativeValue(10)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename')
+    wbSCRI,
+    wbITEX
   ]).SetFormIDBase($40);
 
   wbRecord(LTEX, 'Landscape Texture', [
     wbDELE,
     wbNAME,
-    wbInteger(INTV, 'Texture ID', itU32),
-    wbString(DATA, 'Texture Filename')
-  ]).SetFormIDBase($60);
+    wbInteger(INTV, 'Texture ID', itU32).SetRequired,
+    wbString(DATA, 'Texture Filename').SetRequired
+  ]).SetFormIDBase($60).SetSummaryKey([3]);
 
   wbRecord(MGEF, 'Magic Effect', @wbKnownSubRecordSignaturesINDX, [
     wbInteger(INDX, 'Effect', itU32, wbMagicEffectEnum),
@@ -1379,38 +1588,19 @@ begin
           {4} 'Mysticism',
           {5} 'Restoration'
         ])),
-      wbFloat('Base Cost', cpNormal, False, 1.0, 2),
+      wbFloat('Base Cost', cpNormal, False, 1, 2),
       wbInteger('Flags', itU32,
-        wbFlags([
-          {0}  'Target Skill',
-          {1}  'Target Attribute',
-          {2}  'No Duration',
-          {3}  'No Magnitude',
-          {4}  'Harmful',
-          {5}  'Continuous VFX',
-          {6}  'Cast Self',
-          {7}  'Cast Touch',
-          {8}  'Cast Target',
-          {9}  'Spellmaking',
-          {10} 'Enchanting',
-          {11} 'Negative',
-          {12} 'Applied Once',
-          {13} 'Stealth',
-          {14} 'Non-Recastable',
-          {15} 'Illegal Daedra',
-          {16} 'Non-reflectable',
-          {17} 'Caster Linked'
-        ])).IncludeFlag(dfCollapsed, wbCollapseFlags),
-      wbStruct('Color', [
-        wbInteger('Red', itU32),
-        wbInteger('Green', itU32),
-        wbInteger('Blue', itU32)
-      ]),
-      wbFloat('Size Multiplier', cpNormal, False, 1.0, 2),
-      wbFloat('Speed Multiplier', cpNormal, False, 1.0, 2),
-      wbFloat('Size Cap', cpNormal, False, 1.0, 2)
+        wbFlags(wbSparseFlags([
+          9,  'Spellmaking',
+          10, 'Enchanting',
+          11, 'Negative'
+        ]))).IncludeFlag(dfCollapsed, wbCollapseFlags),
+      wbByteColorsInt32,
+      wbFloat('Size Multiplier', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbFloat('Speed Multiplier', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbFloat('Size Cap', cpNormal, False, 1, 2)
     ]).SetRequired,
-    wbString(ITEX, 'Effect Texture Filename'),
+    wbITEX,
     wbString(PTEX, 'Particle Texture Filename'),
     wbString(BSND, 'Bolt Sound'), //[SOUN]
     wbString(CSND, 'Cast Sound'), //[SOUN]
@@ -1420,96 +1610,99 @@ begin
     wbString(BVFX, 'Bolt Visual'), //[WEAP]
     wbString(HVFX, 'Hit Visual'), //[STAT]
     wbString(AVFX, 'Area Visual'), //[STAT]
-    wbString(DESC, 'Description')
+    wbDESC
   ]).SetFormIDBase($02);
 
-  wbRecord(MISC, 'Miscellaneous Item', [
+  wbRecord(MISC, 'Miscellaneous Item', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(MCDT,'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
-      //This bool is only set true if the object is used in a KNAM on a REFR.
-      wbInteger('Is Key', itU32, wbBoolEnum)
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbInteger('Used As Key', itU32, wbBoolEnum) //This is true if the object is used as a key on a Reference.
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename')
+    wbSCRI,
+    wbITEX
   ]).SetFormIDBase($40);
 
-  wbRecord(NPC_, 'Non-Player Character', [
+  wbRecord(NPC_, 'Non-Player Character', wbFlags(wbFlagsList([
+      10, 'Corpses Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbMODL,
     wbFNAM,
-    wbString(RNAM, 'Race'), //[RACE]
-    wbString(CNAM, 'Class'), //[CLAS]
-    wbString(ANAM, 'Faction'), //[FACT]
-    wbString(BNAM, 'Head Body Part'), //[BODY]
-    wbString(KNAM, 'Hair Body Part'), //[BODY]
-    wbSCRI, //[SCPT]
-    wbStruct(NPDT, 'Data', [
-      wbUnion('Calculated Format', wbNPCDataDecider, [
-        wbStruct('Non-Auto', [
-          wbInteger('Level', itS16),
-          wbStruct('Attributes', [
-            wbInteger('Strength', itU8),
-            wbInteger('Intelligence', itU8),
-            wbInteger('Willpower', itU8),
-            wbInteger('Agility', itU8),
-            wbInteger('Speed', itU8),
-            wbInteger('Endurance', itU8),
-            wbInteger('Personality', itU8),
-            wbInteger('Luck', itU8)
-          ]),
-          wbStruct('Skills', [
-            wbInteger('Block', itU8),
-            wbInteger('Armorer', itU8),
-            wbInteger('Medium Armor', itU8),
-            wbInteger('Heavy Armor', itU8),
-            wbInteger('Blunt Weapon', itU8),
-            wbInteger('Long Blade', itU8),
-            wbInteger('Axe', itU8),
-            wbInteger('Spear', itU8),
-            wbInteger('Athletics', itU8),
-            wbInteger('Enchant', itU8),
-            wbInteger('Destruction', itU8),
-            wbInteger('Alteration', itU8),
-            wbInteger('Illusion', itU8),
-            wbInteger('Conjuration', itU8),
-            wbInteger('Mysticism', itU8),
-            wbInteger('Restoration', itU8),
-            wbInteger('Alchemy', itU8),
-            wbInteger('Unarmored', itU8),
-            wbInteger('Security', itU8),
-            wbInteger('Sneak', itU8),
-            wbInteger('Acrobatics', itU8),
-            wbInteger('Light Armor', itU8),
-            wbInteger('Short Blade', itU8),
-            wbInteger('Marksman', itU8),
-            wbInteger('Speechcraft', itU8),
-            wbInteger('Mercantile', itU8),
-            wbInteger('Hand-to-Hand', itU8)
-          ]),
-          wbUnused(1),
-          wbInteger('Health', itU16),
-          wbInteger('Magicka', itU16),
-          wbInteger('Fatigue', itU16),
-          wbInteger('Disposition', itU8),
-          wbInteger('Reputation', itU8),
-          wbInteger('Rank', itU8),
-          wbUnused(1),
-          wbInteger('Gold', itU32)
+    wbString(RNAM, 'Race').SetDefaultNativeValue('Argonian').SetRequired, //[RACE]
+    wbString(CNAM, 'Class').SetDefaultNativeValue('Acrobat').SetRequired, //[CLAS]
+    wbString(ANAM, 'Faction').SetRequired, //[FACT]
+    wbString(BNAM, 'Head Body Part').SetDefaultNativeValue('b_n_argonian_m_head_03').SetRequired, //[BODY]
+    wbString(KNAM, 'Hair Body Part').SetDefaultNativeValue('b_n_argonian_m_hair02').SetRequired, //[BODY]
+    wbSCRI,
+    wbUnion(NPDT, 'Data', wbNPCDataDecider, [
+      wbStruct('Stats', [
+        wbInteger('Level', itS16).SetDefaultNativeValue(1),
+        wbStruct('Attributes', [
+          wbInteger('Strength', itU8).SetDefaultNativeValue(50),
+          wbInteger('Intelligence', itU8).SetDefaultNativeValue(50),
+          wbInteger('Willpower', itU8).SetDefaultNativeValue(50),
+          wbInteger('Agility', itU8).SetDefaultNativeValue(50),
+          wbInteger('Speed', itU8).SetDefaultNativeValue(50),
+          wbInteger('Endurance', itU8).SetDefaultNativeValue(50),
+          wbInteger('Personality', itU8).SetDefaultNativeValue(50),
+          wbInteger('Luck', itU8).SetDefaultNativeValue(50)
         ]),
-        wbStruct('Auto', [
-          wbInteger('Level', itU16),
-          wbInteger('Disposition', itU8),
-          wbInteger('Reputation', itU8),
-          wbInteger('Rank', itU8),
-          wbUnused(3),
-          wbInteger('Gold', itU32)
-        ])
+        wbStruct('Skills', [
+          wbInteger('Block', itU8).SetDefaultNativeValue(5),
+          wbInteger('Armorer', itU8).SetDefaultNativeValue(5),
+          wbInteger('Medium Armor', itU8).SetDefaultNativeValue(5),
+          wbInteger('Heavy Armor', itU8).SetDefaultNativeValue(5),
+          wbInteger('Blunt Weapon', itU8).SetDefaultNativeValue(5),
+          wbInteger('Long Blade', itU8).SetDefaultNativeValue(5),
+          wbInteger('Axe', itU8).SetDefaultNativeValue(5),
+          wbInteger('Spear', itU8).SetDefaultNativeValue(5),
+          wbInteger('Athletics', itU8).SetDefaultNativeValue(5),
+          wbInteger('Enchant', itU8).SetDefaultNativeValue(5),
+          wbInteger('Destruction', itU8).SetDefaultNativeValue(5),
+          wbInteger('Alteration', itU8).SetDefaultNativeValue(5),
+          wbInteger('Illusion', itU8).SetDefaultNativeValue(5),
+          wbInteger('Conjuration', itU8).SetDefaultNativeValue(5),
+          wbInteger('Mysticism', itU8).SetDefaultNativeValue(5),
+          wbInteger('Restoration', itU8).SetDefaultNativeValue(5),
+          wbInteger('Alchemy', itU8).SetDefaultNativeValue(5),
+          wbInteger('Unarmored', itU8).SetDefaultNativeValue(5),
+          wbInteger('Security', itU8).SetDefaultNativeValue(5),
+          wbInteger('Sneak', itU8).SetDefaultNativeValue(5),
+          wbInteger('Acrobatics', itU8).SetDefaultNativeValue(5),
+          wbInteger('Light Armor', itU8).SetDefaultNativeValue(5),
+          wbInteger('Short Blade', itU8).SetDefaultNativeValue(5),
+          wbInteger('Marksman', itU8).SetDefaultNativeValue(5),
+          wbInteger('Speechcraft', itU8).SetDefaultNativeValue(5),
+          wbInteger('Mercantile', itU8).SetDefaultNativeValue(5),
+          wbInteger('Hand-to-Hand', itU8).SetDefaultNativeValue(5)
+        ]),
+        wbUnused(1),
+        wbInteger('Health', itU16).SetDefaultNativeValue(50),
+        wbInteger('Magicka', itU16).SetDefaultNativeValue(100),
+        wbInteger('Fatigue', itU16).SetDefaultNativeValue(200),
+        wbInteger('Disposition', itU8).SetDefaultNativeValue(50),
+        wbInteger('Reputation', itU8),
+        wbInteger('Rank', itU8),
+        wbUnused(1),
+        wbInteger('Gold', itU32)
+      ]),
+      wbStruct('Auto Calculated Stats', [
+        wbInteger('Level', itU16).SetDefaultNativeValue(1),
+        wbInteger('Disposition', itU8).SetDefaultNativeValue(50),
+        wbInteger('Reputation', itU8),
+        wbInteger('Rank', itU8),
+        wbUnused(3),
+        wbInteger('Gold', itU32)
       ])
     ]).SetRequired,
     wbInteger(FLAG, 'Flags', itU32,
@@ -1521,62 +1714,13 @@ begin
         4, 'Auto Calculate Stats',
         10, 'Skeleton Blood',
         11, 'Metal Blood'
-      ], False, 12))),
-    wbRArray('Item Entries',
-      wbStruct(NPCO, 'Item Entry', [
-        wbInteger('Count', itS32),
-        wbString('Item', 32) //[ALCH, APPA, ARMO, BOOK, CLOT, INGR, LEVI, LIGH, LOCK, MISC, PROB, REPA, WEAP]
-      ])),
-    wbRArray('Spells', wbString(NPCS, 'Spell', 32)), //[SPEL]
+      ], False, 12))).SetDefaultNativeValue(18).IncludeFlag(dfCollapsed, wbCollapseFlags),
+    wbItems,
+    wbSpells,
     wbAIDT,
     wbTravelServices,
-    wbRArray('AI Packages',
-      wbRUnion('AI Packages', [
-        wbStruct(AI_T, 'AI Travel', [
-          wbVec3('Position'),
-          wbInteger('Reset', itU8, wbBoolEnum),
-          wbUnused(3)
-        ]).SetRequired,
-        wbStruct(AI_W, 'AI Wander', [
-          wbInteger('Distance', itU16),
-          wbInteger('Duration In Hours', itU16),
-          wbInteger('Time of Day', itU8),
-          wbStruct('Idle Chances', [
-            wbInteger('Idle 2', itU8),
-            wbInteger('Idle 3', itU8),
-            wbInteger('Idle 4', itU8),
-            wbInteger('Idle 5', itU8),
-            wbInteger('Idle 6', itU8),
-            wbInteger('Idle 7', itU8),
-            wbInteger('Idle 8', itU8),
-            wbInteger('Idle 9', itU8)
-          ]),
-          wbInteger('Reset', itU8, wbBoolEnum)
-        ]).SetRequired,
-        wbRStruct('AI Escort', [
-          wbStruct(AI_E, 'AI Escort', [
-            wbVec3('Position'),
-            wbInteger('Duration In Hours', itU16),
-            wbString(True, 'Target', 32), //[CREA, NPC_]
-            wbInteger('Reset', itU16, wbBoolEnum)
-          ]).SetRequired,
-          wbString(CNDT, 'Escort To Cell') //[CELL]
-        ]),
-        wbRStruct('AI Follow', [
-          wbStruct(AI_F, 'AI Follow', [
-            wbVec3('Position'),
-            wbInteger('Duration In Hours', itU16),
-            wbString(True, 'Target', 32), //[CREA, NPC_]
-            wbInteger('Reset', itU16, wbBoolEnum)
-          ]).SetRequired,
-          wbString(CNDT, 'Follow To Cell') //[CELL]
-        ]),
-        wbStruct(AI_A, 'AI Activate', [
-          wbString(True, 'Target', 32), //[ACTI, ALCH, APPA, ARMO, BODY, BOOK, CLOT, CONT, CREA, DOOR, ENCH, INGR, LIGH, LEVC, LEVI, LOCK, MISC, NPC_, PROB, REPA, SPEL, STAT, WEAP]
-          wbInteger('Reset', itU8, wbBoolEnum)
-        ]).SetRequired
-      ])),
-    wbFloat(XSCL, 'Scale', cpNormal, False, 1.0, 2)
+    wbPackages,
+    wbFloat(XSCL, 'Scale', cpNormal, False, 1, 2).SetDefaultNativeValue(1)
   ]).SetFormIDBase($40);
 
   wbRecord(PGRD, 'Path Grid', [
@@ -1584,33 +1728,30 @@ begin
       wbStruct('Grid', [
         wbInteger('X', itS32),
         wbInteger('Y', itS32)
-      ], cpCritical),
-      wbInteger('Granularity', itU16),
-      wbInteger('Grid Point Count', itU16)
+      ], cpCritical).SetSummaryKey([0, 1])
+                    .SetSummaryMemberPrefixSuffix(0, '(', '')
+                    .SetSummaryMemberPrefixSuffix(1, '', ')')
+                    .SetSummaryDelimiter(', '),
+      wbInteger('Granularity', itU16).SetDefaultNativeValue(1024),
+      wbInteger('Point Count', itU16)
     ]).SetRequired,
-    wbString(NAME, 'Location ID', 0, cpIgnore),
+    wbString(NAME, 'Location', 0, cpIgnore).SetRequired,
     IfThen(wbSimpleRecords,
-      wbArray(PGRP, 'Grid Points',
-        wbByteArray('Grid Point', 16)
-      ).SetCountPathOnValue('DATA\Grid Point Count', False),
-      wbArray(PGRP, 'Grid Points',
-        wbStruct('Grid Point', [
-          wbStruct('Position', [
-            wbInteger('X', itS32),
-            wbInteger('Y', itS32),
-            wbInteger('Z', itS32)
-          ]),
-          wbInteger('User Created Point', itU8, wbBoolEnum),
-          wbInteger('Number of Connections', itU8),
+      wbArray(PGRP, 'Points', wbByteArray('Point', 16)).SetCountPathOnValue('DATA\Point Count', False),
+      wbArray(PGRP, 'Points',
+        wbStruct('Point', [
+          wbVec3PosInt32,
+          wbInteger('User Created', itU8, wbBoolEnum),
+          wbInteger('Connection Count', itU8),
           wbUnused(2)
-        ])
-      ).SetCountPathOnValue('DATA\Grid Point Count', False)),
+        ]).SetSummaryKey([0, 2])
+          .SetSummaryMemberPrefixSuffix(0, '', '')
+          .SetSummaryMemberPrefixSuffix(2, 'Connections: ', '')
+          .IncludeFlag(dfCollapsed)
+        ).SetCountPathOnValue('DATA\Point Count', False)),
     IfThen(wbSimpleRecords,
-      wbByteArray(PGRC, 'Grid Point Connections'),
-      wbArray(PGRC, 'Grid Point Connections',
-        wbArrayS('Grid Point Connection',
-          wbInteger('Point', itU32),
-        wbCalcPGRCSize)))
+      wbByteArray(PGRC, 'Point-to-Point Connections'),
+      wbArray(PGRC, 'Point-to-Point Connections', wbArrayS('Point', wbInteger('Point', itU32), wbCalcPGRCSize)).IncludeFlag(dfCollapsed))
   ]).SetFormIDBase($F0)
     .SetFormIDNameBase($B0).SetGetGridCellCallback(function(const aSubRecord: IwbSubRecord; out aGridCell: TwbGridCell): Boolean begin
       with aGridCell, aSubRecord do begin
@@ -1621,7 +1762,7 @@ begin
     end)
     .SetGetFormIDCallback(function(const aMainRecord: IwbMainRecord; out aFormID: TwbFormID): Boolean begin
       var GridCell: TwbGridCell;
-      Result := aMainRecord.GetGridCell(GridCell) and GridCellToFormID($E0, GridCell, aFormID);
+      Result := aMainRecord.GetGridCell(GridCell) and wbGridCellToFormID($E0, GridCell, aFormID);
     end)
     .SetIdentityCallback(function(const aMainRecord: IwbMainRecord): string begin
       var GridCell: TwbGridCell;
@@ -1631,73 +1772,79 @@ begin
         Result := aMainRecord.EditorID;
     end);
 
-  wbRecord(PROB, 'Probe', [
+  wbRecord(PROB, 'Probe', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(PBDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
-      wbFloat('Quality', cpNormal, False, 1.0, 2),
-      wbInteger('Uses', itS32)
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbFloat('Quality', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Uses', itU32).SetDefaultNativeValue(10)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename')
+    wbSCRI,
+    wbITEX
   ]).SetFormIDBase($40);
 
   wbRecord(RACE, 'Race', [
     wbNAME,
     wbDELE,
-    wbFNAM,
+    wbFNAM.SetRequired,
     wbStruct(RADT, 'Data', [
-      wbArray('Skill Bonuses',
-        wbStruct('Skill Bonus', [
+      wbArrayS('Skill Bonuses',
+        wbStructSK([0], 'Skill Bonus', [
           wbInteger('Skill', itS32, wbSkillEnum),
-          wbInteger('Bonus', itS32)
-        ]),
-      7),
+          wbInteger('Bonus', itU32)
+        ]).SetSummaryKey([1, 0])
+          .SetSummaryMemberPrefixSuffix(1, '+', '')
+          .SetSummaryMemberPrefixSuffix(0, '', '')
+          .IncludeFlag(dfSummaryNoSortKey)
+          .IncludeFlag(dfSummaryMembersNoName).IncludeFlag(dfCollapsed), 7),
       wbStruct('Base Attributes', [
         wbStruct('Strength', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Intelligence', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Willpower', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Agility', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Speed', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Endurance', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Personality', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ]),
         wbStruct('Luck', [
-          wbInteger('Male', itS32),
-          wbInteger('Female', itS32)
+          wbInteger('Male', itU32).SetDefaultNativeValue(50),
+          wbInteger('Female', itU32).SetDefaultNativeValue(50)
         ])
       ]),
       wbStruct('Height', [
-        wbFloat('Male', cpNormal, False, 1.0, 2),
-        wbFloat('Female', cpNormal, False, 1.0, 2)
+        wbFloat('Male', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+        wbFloat('Female', cpNormal, False, 1, 2).SetDefaultNativeValue(1)
       ]),
       wbStruct('Weight', [
-        wbFloat('Male', cpNormal, False, 1.0, 2),
-        wbFloat('Female', cpNormal, False, 1.0, 2)
+        wbFloat('Male', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+        wbFloat('Female', cpNormal, False, 1, 2).SetDefaultNativeValue(1)
       ]),
       wbInteger('Flags', itU32,
         wbFlags([
@@ -1705,50 +1852,43 @@ begin
           {1} 'Beast Race'
         ])).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired,
-    wbRArray('Spells', wbStringForward(NPCS, 'Spell', 32)),
-    wbString(DESC, 'Description')
+    wbSpells,
+    wbDESC
   ]).SetFormIDBase($14);
 
-  wbRecord(REFR, 'Reference', @wbKnownSubRecordSignaturesREFR, [
-    wbStruct(CNDT, 'Previous Cell Grid', [
+  wbRecord(REFR, 'Placed Object', @wbKnownSubRecordSignaturesREFR, [
+    wbStruct(CNDT, 'New Cell Owner', [
       wbInteger('X', itS32),
       wbInteger('Y', itS32)
-    ]),
-    wbInteger(FRMR, 'Object Index', itU32, wbFRMRToString, nil, cpIgnore, True).IncludeFlag(dfInternalEditOnly),
+    ]).SetSummaryKeyOnValue([0, 1])
+      .SetSummaryPrefixSuffixOnValue(0, '(', '')
+      .SetSummaryPrefixSuffixOnValue(1, '', ')')
+      .SetSummaryDelimiterOnValue(', '),
+    wbInteger(FRMR, 'Object Index', itU32, wbFRMRToString, nil, cpIgnore, True).IncludeFlag(dfInternalEditOnly).SetRequired,
     wbString(NAME, 'Base Object'), //[ACTI, ALCH, APPA, ARMO, BODY, BOOK, CLOT, CONT, CREA, DOOR, INGR, LEVC, LOCK, MISC, NPC_, PROB, REPA, STAT, WEAP]
-    wbInteger(UNAM, 'Reference Blocked', itU8, wbEnum(['Blocked'])),
+    wbInteger(UNAM, 'Reference Blocked', itU8, wbEnum(['True'])),
     wbFloat(XSCL, 'Scale', cpNormal, False, 1, 2),
     wbRStructSK([], 'Owner Data', [
       wbString(ANAM, 'Owner'), //[NPC_]
       wbString(BNAM, 'Global Variable'), //[GLOB]
       wbString(CNAM, 'Faction Owner'), //[FACT]
-      wbInteger(INDX, 'Faction Rank', itS32)
+      wbInteger(INDX, 'Faction Rank', itU32)
     ], [], cpNormal, False, nil, True),
-    wbFloat(XCHG, 'Enchanting Charge', cpNormal, False, 1, 0),
+    wbFloat(XCHG, 'Enchantment Charge', cpNormal, False, 1, 0),
     wbString(XSOL, 'Soul'), //[CREA]
-    wbInteger(INTV, 'Health', itS32),
-    wbInteger(NAM9, 'Count', itS32),
-    wbRStructSK([], 'Teleport Data', [
-      wbStruct(DODT, 'Teleport Destination', [
-        wbVec3('Position'),
-        wbVec3('Rotation')
-      ]),
-      wbString(DNAM, 'Teleport Cell') //[CELL]
+    wbInteger(INTV, 'Health/Uses Left', itU32),
+    wbInteger(NAM9, 'Count', itU32),
+    wbRStructSK([], 'Teleport Destination', [
+      wbVec3PosRot(DODT, 'Position/Rotation'),
+      wbString(DNAM, 'Cell') //[CELL]
     ]),
     wbRStructSK([], 'Lock Data', [
-      wbInteger(FLTV, 'Lock Level', itU32),
+      wbInteger(FLTV, 'Lock Level', itU32).SetRequired,
       wbString(KNAM, 'Key'), //[MISC]
       wbString(TNAM, 'Trap') //[ENCH]
     ], [], cpNormal, False, nil, True),
-    wbInteger(DELE, 'Deleted', itU32,
-      wbEnum([], [
-        $00482C64, 'Deleted',
-        $11842014, 'Deleted (Door Reference)'
-    ])).SetDefaultNativeValue(4729956),
-    wbStruct(DATA, 'Reference Data', [
-      wbVec3('Position'),
-      wbVec3('Rotation')
-    ])
+    wbDELE,
+    wbVec3PosRot(DATA)
   ]).SetGetFormIDCallback(function(const aMainRecord: IwbMainRecord; out aFormID: TwbFormID): Boolean begin
       var lFRMR := aMainRecord.RecordBySignature[FRMR];
       Result := Assigned(lFRMR);
@@ -1757,60 +1897,71 @@ begin
         if aFormID.FileID.FullSlot = 0 then
           aFormID.FileID := TwbFileID.CreateFull($FF);
       end;
-    end);
+    end).SetAfterLoad(wbDELEAfterLoad);
 
   wbRecord(REGN, 'Region', [
     wbDELE,
     wbNAME,
-    wbFNAM,
+    wbFNAM.SetRequired,
     wbStruct(WEAT, 'Weather Chances', [
-      wbInteger('Clear', itU8),
-      wbInteger('Cloudy', itU8),
-      wbInteger('Foggy', itU8),
-      wbInteger('Overcast', itU8),
-      wbInteger('Rain', itU8),
-      wbInteger('Thunder', itU8),
+      wbInteger('Clear', itU8).SetDefaultNativeValue(5),
+      wbInteger('Cloudy', itU8).SetDefaultNativeValue(25),
+      wbInteger('Foggy', itU8).SetDefaultNativeValue(35),
+      wbInteger('Overcast', itU8).SetDefaultNativeValue(20),
+      wbInteger('Rain', itU8).SetDefaultNativeValue(10),
+      wbInteger('Thunder', itU8).SetDefaultNativeValue(5),
       wbInteger('Ash', itU8),
       wbInteger('Blight', itU8),
       wbInteger('Snow', itU8),
       wbInteger('Blizzard', itU8)
-    ], cpNormal, True, nil, 8),
+    ], cpNormal, True, nil, 8).SetRequired,
     wbString(BNAM, 'Sleep Creature'), //[LEVC]
-    wbByteColors(CNAM, 'Map Color'),
-    wbRArray('Sound Records',
-      wbStruct(SNAM, 'Sound Record', [
-        wbString(True, 'Sound', 32), //[SOUN]
-        wbInteger('Chance', itS8)
-      ]))
+    wbByteColors(CNAM, 'Region Map Color').SetRequired,
+    wbRArrayS('Region Sounds',
+      wbStructSK(SNAM, [0], 'Region Sound', [
+        wbString(True, 'Sound', 32).SetAfterLoad(wbForwardForRealz), //[SOUN]
+        wbInteger('Chance', itS8).SetDefaultNativeValue(50)
+      ]).SetSummaryKeyOnValue([0, 1])
+        .SetSummaryPrefixSuffixOnValue(0, 'Sound: ', ',')
+        .SetSummaryPrefixSuffixOnValue(1, 'Chance: ', '').IncludeFlag(dfCollapsed))
   ]).SetFormIDBase($70);
 
-  wbRecord(REPA, 'Repair Item', [
+  wbRecord(REPA, 'Repair Item', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(RIDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
-      wbInteger('Uses', itS32),
-      wbFloat('Quality', cpNormal, False, 1.0, 2)
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
+      wbInteger('Uses', itU32).SetDefaultNativeValue(10),
+      wbFloat('Quality', cpNormal, False, 1, 2).SetDefaultNativeValue(1)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename')
+    wbSCRI,
+    wbITEX
   ]).SetFormIDBase($40);
 
   wbRecord(SCPT, 'Script', @wbKnownSubRecordSignaturesSCPT, [
     wbStruct(SCHD, 'Script Header', [
-      //Name can be saved with 36 characters in the CS, but it collides with Number of Shorts.
-      wbString('Name', 32),
+      wbString('Name', 32), //Can be saved with 36 Chars in the CS, but collides with # of Shorts.
       wbInteger('Number of Shorts', itU32),
       wbInteger('Number of Longs', itU32),
       wbInteger('Number of Floats', itU32),
-      wbInteger('Script Data Size', itU32),
+      wbInteger('Compiled Size', itU32),
       wbInteger('Local Variable Size', itU32)
-    ]).SetRequired,
+    ]).SetSummaryKeyOnValue([4, 5, 2, 1, 3])
+      .SetSummaryPrefixSuffixOnValue(4, '{Compiled Size = ', ',')
+      .SetSummaryPrefixSuffixOnValue(5, 'Local Var Size = ', ',')
+      .SetSummaryPrefixSuffixOnValue(1, 'Shorts = ', ',')
+      .SetSummaryPrefixSuffixOnValue(2, 'Longs = ', ',')
+      .SetSummaryPrefixSuffixOnValue(3, 'Floats = ', '}')
+      .IncludeFlagOnValue(dfSummaryMembersNoName)
+      .IncludeFlag(dfCollapsed, wbCollapseScriptData).SetRequired,
     wbDELE,
-    wbArray(SCVR, 'Script Variables', wbString('Script Variable', 0, cpCritical)),
+    wbArrayS(SCVR, 'Script Variables', wbString('Script Variable', 0, cpCritical)),
     wbByteArray(SCDT, 'Compiled Script'),
     wbStringScript(SCTX, 'Script Source').SetRequired
   ]).SetFormIDBase($30)
@@ -1819,18 +1970,79 @@ begin
     end)
     .SetSetEditorIDCallback(procedure (const aSubRecord: IwbSubRecord; const aEditorID: string) begin
       aSubRecord.ElementEditValues['Name'] := aEditorID;
-    end);
+    end)
+    .SetToStr(wbScriptToStr);
 
   wbRecord(SKIL, 'Skill', @wbKnownSubRecordSignaturesINDX, [
-    wbInteger(INDX, 'Name', itU32, wbSkillEnum),
+    wbInteger(INDX, 'Name', itU32, wbSkillEnum).SetRequired,
     wbStruct(SKDT, 'Data', [
-      wbInteger('Attribute', itS32, wbAttributeEnum),
+      wbInteger('Governing Attribute', itS32, wbAttributeEnum),
       wbInteger('Type', itU32, wbSpecializationEnum),
-      wbArray('Actions',
-        wbFloat('Action'),
-      4)
+      wbUnion('Actions', wbSkillDecider, [
+        wbStruct('Block', [
+          wbFloat('Successful Block'),
+          wbUnused(12)
+        ]),
+        wbStruct('Armorer', [
+          wbFloat('Successful Repair'),
+          wbUnused(12)
+        ]),
+        wbStruct('Armor', [
+          wbFloat('Hit By Opponent'),
+          wbUnused(12)
+        ]),
+        wbStruct('Weapon', [
+          wbFloat('Successful Attack'),
+          wbUnused(12)
+        ]),
+        wbStruct('Athletics', [
+          wbFloat('Seconds of Running'),
+          wbFloat('Seconds of Swimming'),
+          wbUnused(8)
+        ]),
+        wbStruct('Enchant', [
+          wbFloat('Recharge Item'),
+          wbFloat('Use Magic Item'),
+          wbFloat('Create Magic Item'),
+          wbFloat('Cast When Strikes')
+        ]),
+        wbStruct('Magic School', [
+          wbFloat('Successful Cast'),
+          wbUnused(12)
+        ]),
+        wbStruct('Alchemy', [
+          wbFloat('Potion Creation'),
+          wbFloat('Ingredient Use'),
+          wbUnused(8)
+        ]),
+        wbStruct('Security', [
+          wbFloat('Defeat Trap'),
+          wbFloat('Pick Lock'),
+          wbUnused(8)
+        ]),
+        wbStruct('Sneak', [
+          wbFloat('Avoid Notice'),
+          wbFloat('Successful Pick-Pocket'),
+          wbUnused(8)
+        ]),
+        wbStruct('Acrobatics', [
+          wbFloat('Jump'),
+          wbFloat('Fall'),
+          wbUnused(8)
+        ]),
+        wbStruct('Mercantile', [
+          wbFloat('Successful Bargain'),
+          wbFloat('Successful Bribe'),
+          wbUnused(8)
+        ]),
+        wbStruct('Speechcraft', [
+          wbFloat('Successful Persuasion'),
+          wbFloat('Failed Persuasion'),
+          wbUnused(8)
+        ])
+      ])
     ]).SetRequired,
-    wbString(DESC, 'Description')
+    wbDESC
   ]).SetFormIDBase($01);
 
   wbRecord(SNDG, 'Sound Generator', [
@@ -1845,24 +2057,26 @@ begin
         {5} 'Roar',
         {6} 'Scream',
         {7} 'Land'
-      ])),
+      ])).SetDefaultNativeValue(7).SetRequired,
     wbString(CNAM, 'Creature'), //[CREA]
-    wbString(SNAM, 'Sound'), //[SOUN]
+    wbString(SNAM, 'Sound').SetDefaultNativeValue('Body Fall Medium').SetRequired, //[SOUN]
     wbDELE
-  ]).SetFormIDBase($28);
+  ]).SetFormIDBase($28).SetSummaryKey([3]);
 
-  wbRecord(SOUN, 'Sound', @wbKnownSubRecordSignaturesNoFNAM, [
+  wbRecord(SOUN, 'Sound', [
     wbNAME,
     wbDELE,
-    wbString(FNAM, 'Sound Filename'),
+    wbString(FNAM, 'Sound Filename').SetRequired,
     wbStruct(DATA, 'Data', [
-      wbInteger('Volume', itU8),
+      wbInteger('Volume', itU8, wbDiv(255, 2)).SetDefaultNativeValue(1),
       wbInteger('Minimum Range', itU8),
       wbInteger('Maximum Range', itU8)
     ]).SetRequired
   ]).SetFormIDBase($40);
 
-  wbRecord(SPEL, 'Spellmaking', [
+  wbRecord(SPEL, 'Spell', wbFlags(wbFlagsList([
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
     wbFNAM,
@@ -1876,72 +2090,76 @@ begin
           {4} 'Curse',
           {5} 'Power'
         ])),
-      wbInteger('Spell Cost', itS32),
+      wbInteger('Spell Cost', itU32),
       wbInteger('Flags', itU32,
         wbFlags([
           {0} 'Auto Calculate Cost',
-          {1} 'PC Start Spell',
+          {1} 'Player Start Spell',
           {2} 'Always Succeeds'
         ])).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired,
-    wbENAM
+    wbEffects
   ]).SetFormIDBase($0A);
 
   wbRecord(SSCR, 'Start Script', @wbKnownSubRecordSignaturesSSCR, [
-    wbInteger(DELE, 'Deleted', itU32,
-      wbEnum([],[1, 'Deleted'])
-    ).SetDefaultNativeValue(1),
-    wbString(DATA, 'Numerical ID'),
-    wbString(NAME, 'Script') //[SCPT]
-  ]).SetFormIDBase($3F);
+    wbDELE,
+    wbString(DATA, 'Numerical ID').SetRequired,
+    wbString(NAME, 'Script').SetRequired //[SCPT]
+  ]).SetFormIDBase($3F).SetAfterLoad(wbDELEAfterLoad);
 
-  wbRecord(STAT, 'Static', [
+  wbRecord(STAT, 'Static', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL
-  ]).SetFormIDBase($40);
+    wbMODL.SetRequired
+  ]).SetFormIDBase($40).SetSummaryKey([2]);
 
-  wbRecord(WEAP, 'Weapon', [
+  wbRecord(WEAP, 'Weapon', wbFlags(wbFlagsList([
+      10, 'References Persist',
+      13, 'Blocked'
+    ])), [
     wbNAME,
     wbDELE,
-    wbMODL,
+    wbMODL.SetRequired,
     wbFNAM,
     wbStruct(WPDT, 'Data', [
-      wbFloat('Weight', cpNormal, False, 1.0, 2),
-      wbInteger('Value', itS32),
+      wbFloat('Weight', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Value', itU32).SetDefaultNativeValue(1),
       wbInteger('Type', itU16,
         wbEnum([
-          {0}  'Short Blade One Hand',
-          {1}  'Long Blade One Hand',
-          {2}  'Long Blade Two Close',
-          {3}  'Blunt One Hand',
-          {4}  'Blunt Two Close',
-          {5}  'Blunt Two Wide',
-          {6}  'Spear Two Wide',
-          {7}  'Axe One Hand',
-          {8}  'Axe Two Hand',
-          {9}  'Marksman Bow',
+           {0} 'Short Blade One Hand',
+           {1} 'Long Blade One Hand',
+           {2} 'Long Blade Two Close',
+           {3} 'Blunt One Hand',
+           {4} 'Blunt Two Close',
+           {5} 'Blunt Two Wide',
+           {6} 'Spear Two Wide',
+           {7} 'Axe One Hand',
+           {8} 'Axe Two Hand',
+           {9} 'Marksman Bow',
           {10} 'Marksman Crossbow',
           {11} 'Marksman Thrown',
           {12} 'Arrow',
           {13} 'Bolt'
-        ])),
-      wbInteger('Health', itU16),
-      wbFloat('Speed'),
-      wbFloat('Reach'),
-      wbInteger('Enchanting Charge', itU16),
+        ])).SetDefaultNativeValue(12),
+      wbInteger('Health', itU16).SetDefaultNativeValue(100),
+      wbFloat('Speed', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbFloat('Reach', cpNormal, False, 1, 2).SetDefaultNativeValue(1),
+      wbInteger('Enchantment Charge', itU16).SetDefaultNativeValue(100),
       wbStruct('Damage Types', [
         wbStruct('Chop', [
-          wbInteger('Minimum', itU8),
-          wbInteger('Maximum', itU8)
+          wbInteger('Minimum', itU8).SetDefaultNativeValue(1),
+          wbInteger('Maximum', itU8).SetDefaultNativeValue(5)
         ]),
         wbStruct('Slash', [
-          wbInteger('Minimum', itU8),
-          wbInteger('Maximum', itU8)
+          wbInteger('Minimum', itU8).SetDefaultNativeValue(1),
+          wbInteger('Maximum', itU8).SetDefaultNativeValue(5)
         ]),
         wbStruct('Thrust', [
-          wbInteger('Minimum', itU8),
-          wbInteger('Maximum', itU8)
+          wbInteger('Minimum', itU8).SetDefaultNativeValue(1),
+          wbInteger('Maximum', itU8).SetDefaultNativeValue(5)
         ])
       ]),
       wbInteger('Flags', itU32,
@@ -1950,9 +2168,9 @@ begin
           {1} 'Ignore Normal Weapon Resistance'
         ])).IncludeFlag(dfCollapsed, wbCollapseFlags)
     ]).SetRequired,
-    wbSCRI, //[SCPT]
-    wbString(ITEX, 'Icon Filename'),
-    wbString(ENAM, 'Enchantment') //[ENCH]
+    wbSCRI,
+    wbITEX,
+    wbENAM
   ]).SetFormIDBase($40);
 
   wbAddGroupOrder(GMST);

--- a/Core/wbDefinitionsTES4.pas
+++ b/Core/wbDefinitionsTES4.pas
@@ -1087,16 +1087,16 @@ begin
 
   wbActorValueEnum :=
     wbEnum([
-      {0}  'Strength',
-      {1}  'Intelligence',
-      {2}  'Willpower',
-      {3}  'Agility',
-      {4}  'Speed',
-      {5}  'Endurance',
-      {6}  'Personality',
-      {7}  'Luck',
-      {8}  'Health',
-      {9}  'Magicka',
+       {0} 'Strength',
+       {1} 'Intelligence',
+       {2} 'Willpower',
+       {3} 'Agility',
+       {4} 'Speed',
+       {5} 'Endurance',
+       {6} 'Personality',
+       {7} 'Luck',
+       {8} 'Health',
+       {9} 'Magicka',
       {10} 'Fatigue',
       {11} 'Encumbrance',
       {12} 'Armorer',
@@ -1233,47 +1233,48 @@ begin
       {2} 'Destruction',
       {3} 'Illusion',
       {4} 'Mysticism',
-      {5} 'Restoration'
+      {5} 'Restoration',
+      {6} 'None'
     ]);
 
   wbMajorSkillEnum :=
     wbEnum([], [
       -1, 'None',
-      12,  'Armorer',
-      13,  'Athletics',
-      14,  'Blade',
-      15,  'Block',
-      16,  'Blunt',
-      17,  'Hand To Hand',
-      18,  'Heavy Armor',
-      19,  'Alchemy',
-      20,  'Alteration',
-      21,  'Conjuration',
-      22,  'Destruction',
-      23,  'Illusion',
-      24,  'Mysticism',
-      25,  'Restoration',
-      26,  'Acrobatics',
-      27,  'Light Armor',
-      28,  'Marksman',
-      29,  'Mercantile',
-      30,  'Security',
-      31,  'Sneak',
-      32,  'Speechcraft'
+      12, 'Armorer',
+      13, 'Athletics',
+      14, 'Blade',
+      15, 'Block',
+      16, 'Blunt',
+      17, 'Hand To Hand',
+      18, 'Heavy Armor',
+      19, 'Alchemy',
+      20, 'Alteration',
+      21, 'Conjuration',
+      22, 'Destruction',
+      23, 'Illusion',
+      24, 'Mysticism',
+      25, 'Restoration',
+      26, 'Acrobatics',
+      27, 'Light Armor',
+      28, 'Marksman',
+      29, 'Mercantile',
+      30, 'Security',
+      31, 'Sneak',
+      32, 'Speechcraft'
     ]);
 
   wbMiscStatEnum :=
     wbEnum([
-      {0}  'Days In Prison',
-      {1}  'Days Passed',
-      {2}  'Skill Increases',
-      {3}  'Training Sessions',
-      {4}  'Largest Bounty',
-      {5}  'Creatures Killed',
-      {6}  'People Killed',
-      {7}  'Places Discovered',
-      {8}  'Locks Picked',
-      {9}  'Picks Broken',
+       {0} 'Days In Prison',
+       {1} 'Days Passed',
+       {2} 'Skill Increases',
+       {3} 'Training Sessions',
+       {4} 'Largest Bounty',
+       {5} 'Creatures Killed',
+       {6} 'People Killed',
+       {7} 'Places Discovered',
+       {8} 'Locks Picked',
+       {9} 'Picks Broken',
       {10} 'Souls Trapped',
       {11} 'Ingredients Eaten',
       {12} 'Potions Made',
@@ -1310,29 +1311,29 @@ begin
 
   wbSkillEnum :=
     wbEnum([
-      {0}   'Armorer',
-      {1}   'Athletics',
-      {2}   'Blade',
-      {3}   'Block',
-      {4}   'Blunt',
-      {5}   'Hand To Hand',
-      {6}   'Heavy Armor',
-      {7}   'Alchemy',
-      {8}   'Alteration',
-      {9}   'Conjuration',
-      {10}  'Destruction',
-      {11}  'Illusion',
-      {12}  'Mysticism',
-      {13}  'Restoration',
-      {14}  'Acrobatics',
-      {15}  'Light Armor',
-      {16}  'Marksman',
-      {17}  'Mercantile',
-      {18}  'Security',
-      {19}  'Sneak',
-      {20}  'Speechcraft'
+       {0} 'Armorer',
+       {1} 'Athletics',
+       {2} 'Blade',
+       {3} 'Block',
+       {4} 'Blunt',
+       {5} 'Hand To Hand',
+       {6} 'Heavy Armor',
+       {7} 'Alchemy',
+       {8} 'Alteration',
+       {9} 'Conjuration',
+      {10} 'Destruction',
+      {11} 'Illusion',
+      {12} 'Mysticism',
+      {13} 'Restoration',
+      {14} 'Acrobatics',
+      {15} 'Light Armor',
+      {16} 'Marksman',
+      {17} 'Mercantile',
+      {18} 'Security',
+      {19} 'Sneak',
+      {20} 'Speechcraft'
     ], [
-      -1, 'None'
+       -1, 'None'
     ]);
 
   wbSpecializationEnum :=
@@ -1346,16 +1347,16 @@ begin
 
   wbBipedFlags :=
     wbFlags([
-      {0}  'Head',
-      {1}  'Hair',
-      {2}  'Upper Body',
-      {3}  'Lower Body',
-      {4}  'Hand',
-      {5}  'Foot',
-      {6}  'Right Ring',
-      {7}  'Left Ring',
-      {8}  'Amulet',
-      {9}  'Weapon',
+       {0} 'Head',
+       {1} 'Hair',
+       {2} 'Upper Body',
+       {3} 'Lower Body',
+       {4} 'Hand',
+       {5} 'Foot',
+       {6} 'Right Ring',
+       {7} 'Left Ring',
+       {8} 'Amulet',
+       {9} 'Weapon',
       {10} 'Back Weapon',
       {11} 'Side Weapon',
       {12} 'Quiver',
@@ -1382,7 +1383,7 @@ begin
   wbEDID := wbString(EDID, 'Editor ID', 0, cpNormal); // not cpBenign according to Arthmoor
   wbFULL := wbStringKC(FULL, 'Name', 0, cpTranslate);
   wbFULLReq := wbStringKC(FULL, 'Name', 0, cpTranslate).SetRequired;
-  wbICON := wbString(ICON, 'Icon FileName');
+  wbICON := wbString(ICON, 'Icon Filename');
   wbSCRI := wbFormIDCk(SCRI, 'Script', [SCPT]);
   wbSPLOs := wbRArrayS('Spells', wbFormIDCkST(SPLO, 'Spell', [LVSP, SPEL]));
   wbXSCL := wbFloat(XSCL, 'Scale');
@@ -1391,18 +1392,18 @@ begin
 
   wbConditionParameters := [
   //Misc
-  {0} wbUnknown(4),
-  {1} wbByteArray('None', 4, cpIgnore).IncludeFlag(dfZeroSortKey),
-  {2} wbInteger('Integer', itS32),
-  {3} wbInteger('Quest Stage', itS32, wbConditionQuestStageToStr, wbQuestStageToInt),
-  {4} wbInteger('Variable Name', itS32, wbConditionVariableNameToStr, wbConditionVariableNameToInt),
+   {0} wbUnknown(4),
+   {1} wbByteArray('None', 4, cpIgnore).IncludeFlag(dfZeroSortKey),
+   {2} wbInteger('Integer', itS32),
+   {3} wbInteger('Quest Stage', itS32, wbConditionQuestStageToStr, wbQuestStageToInt),
+   {4} wbInteger('Variable Name', itS32, wbConditionVariableNameToStr, wbConditionVariableNameToInt),
 
   //Enums
-  {5}  wbInteger('Actor Value', itS32, wbActorValueEnum),
-  {6}  wbInteger('Axis', itU32, wbAxisEnum),
-  {7}  wbInteger('Crime Type', itU32, wbCrimeTypeEnum),
-  {8}  wbInteger('Form Type', itU32, wbFormTypeEnum),
-  {9}  wbInteger('Menu Mode', itU32, wbMenuModeEnum),
+   {5} wbInteger('Actor Value', itS32, wbActorValueEnum),
+   {6} wbInteger('Axis', itU32, wbAxisEnum),
+   {7} wbInteger('Crime Type', itU32, wbCrimeTypeEnum),
+   {8} wbInteger('Form Type', itU32, wbFormTypeEnum),
+   {9} wbInteger('Menu Mode', itU32, wbMenuModeEnum),
   {10} wbInteger('Misc Stat', itU32, wbMiscStatEnum),
   {11} wbInteger('Sex', itU32, wbSexEnum),
 
@@ -1623,7 +1624,7 @@ begin
                 wbStructSK(SCIT, [0], 'Script Effect Data', [
                   wbFormIDCk('Script effect', [SCPT, NULL]),
                   wbInteger('Magic school', itU32, wbMagicSchoolEnum),
-                  wbStringMgefCode('Visual Effect Code', 4),
+                  wbStringMgefCode('Visual Effect Code', 4), //Add Union for null code? KURO
                   wbInteger('Hostile', itU8, wbBoolEnum),
                   wbUnused(3)
                 ], cpNormal, True, nil, 1),
@@ -1631,8 +1632,32 @@ begin
               ]),
               wbString(EFII, 'Icon'),
               wbStructSK(EFIX, [3], '', [
-                wbInteger('Override Mask', itU32, wbFlags([])),
-                wbInteger('Flags', itU32, wbFlags([])),
+                wbInteger('Override Flags', itU32, wbFlags(wbSparseFlags([
+                   //Incomplete
+                   0, 'Script Hostility',
+                   1, 'Effects',
+                   2, 'Lowers Actor Value (Default Is False), Flag A On, Flag A Off',
+                   3, 'Hostility',
+                   4, 'Script/EFIX',
+                   5, 'School',
+                   6, 'Name',
+                   7, 'VFX Code',
+                   8, 'Base Cost',
+                   9, 'Resistance',
+                  11, 'Icon',
+                  16, 'Special Treatment for Abilities (Default Is False), Flag B On, Flag B Off',
+                  19, 'Base, Max, Offset, Damage, Script Effect Off, Script Effect On, Flag C On, Flag C Off',
+                  20, 'Base, Max, Offset, Damage, Script Effect Off, Script Effect On, Flag D On, Flag D Off'
+                ]))),
+                wbInteger('Flags', itU32, wbFlags(wbSparseFlags([
+                   //Incomplete
+                   1, 'Override is Null',
+                   2, 'Lowers Actor Value Is True, Flag A On, Flag B On, Flag C On, Flag D On',
+                   3, 'Hostility - Beneficial',
+                  16, 'Special Treatment for Abilities Is True, Flag A On, Flag B On, Flag C On, Flag D On',
+                  19, 'Base, Offset, Script Effect On, FormID, Flag A On, Flag C On',
+                  20, 'Base, Damage, Script Effect On, MGEFCode, Flag B On, Flag D On'
+                ]))),
                 wbFloat('Base Cost'),
                 wbUnion('Param #2', wbEFIXParamDecider, [
                   wbByteArray('Param #2 - Unknown Type', 4),
@@ -1640,7 +1665,7 @@ begin
                   wbStringMgefCode('Param #2 - Magic Effect Code', 4),
                   wbFormIDCk('Param #2 - Actor Value', [ACVA])
                 ]),
-                wbUnknown
+                wbByteArray('Unknown', 16)
               ]).SetAfterLoad(wbEFITAfterLoad)
                 .SetRequired
             ])),
@@ -1677,13 +1702,21 @@ begin
       4, 'Optimized'
     ])), [
     wbHEDR,
-    wbByteArray(OFST, 'Unknown', 0, cpIgnore),
-    wbByteArray(DELE, 'Unknown', 0, cpIgnore),
+    IfThen(wbSimpleRecords,
+      wbByteArray(OFST, 'Offset Load Order', 0, cpIgnore),
+      wbArray(OFST, 'Offset Load Order',
+        wbStruct('Form', [
+          wbInteger('Index', itU8),
+          wbUnused(3),
+          wbString('Form Type', 4),
+          wbInteger('Offset (Unused)', itU32)
+        ]), 0, nil, nil, cpIgnore).IncludeFlag(dfCollapsed)),
+    wbByteArray(DELE, 'Version Control (Unused)', 8, cpIgnore),
     wbString(CNAM, 'Author', 0, cpTranslate).SetRequired,
     wbString(SNAM, 'Description', 0, cpTranslate),
     wbRArray('Master Files',
       wbRStruct('Master File', [
-        wbStringForward(MAST, 'FileName').SetRequired,
+        wbStringForward(MAST, 'Filename').SetRequired,
         wbUnused(DATA, 8).SetRequired
       ])).IncludeFlag(dfInternalEditOnly, not wbAllowMasterFilesEdit)
   ], False, nil, cpNormal, True);
@@ -1802,14 +1835,14 @@ begin
     wbStruct(DATA, 'Data', [
       wbInteger('Type', itU8,
         wbEnum([
-          {0} 'Mortar and Pestle',
+          {0} 'Mortar & Pestle',
           {1} 'Alembic',
           {2} 'Calcinator',
           {3} 'Retort'
         ])),
       wbInteger('Value', itU32),
-      wbFloat('Weight'),
-      wbFloat('Quality')
+      wbFloat('Weight', cpNormal, False, 1, 4),
+      wbFloat('Quality', cpNormal, False, 1, 0)
     ]).SetRequired
   ]);
 
@@ -1873,7 +1906,7 @@ begin
   wbRecord(BSGN, 'Birthsign', [
     wbEDID.SetRequired,
     wbFULL,
-    wbICON,
+    wbString(ICON, 'Constellation Filename'),
     wbDESC.SetRequired,
     wbSPLOs
   ]);
@@ -1891,7 +1924,7 @@ begin
         0, 'Is Interior Cell',
         1, 'Has Water',
         2, 'Can''t Travel From Here',
-        3, 'Force Hide Land (Exterior) / Oblivion Interior Iinterior)',
+        3, 'Force Hide Land (Exterior) / Oblivion Interior (Interior)',
         5, 'Public Area',
         6, 'Hand Changed',
         7, 'Behave Like Exterior'
@@ -1932,7 +1965,7 @@ begin
     wbEDID.SetRequired,
     wbFULL,
     wbDESC.SetRequired,
-    wbICON,
+    wbString(ICON, 'Image Filename'),
     wbStruct(DATA, 'Data', [
       wbStruct('Primary Attributes', [
         wbInteger('Attribute #1', itU32, wbAttributeEnum),
@@ -2021,14 +2054,14 @@ begin
       ).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbFloat('Weight')
     ]).SetRequired,
-    wbFormIDCk(SNAM, 'Open sound', [SOUN]),
-    wbFormIDCk(QNAM, 'Close sound', [SOUN])
+    wbFormIDCk(SNAM, 'Open Sound', [SOUN]),
+    wbFormIDCk(QNAM, 'Close Sound', [SOUN])
   ]);
 
   wbRecord(CREA, 'Creature',
     wbFlags(wbFlagsList([
       10, 'Quest Item',
-      19, 'Unknown 19'
+      19, 'Spawns Dead'
     ])), [
     wbEDID,
     wbFULL,
@@ -2148,14 +2181,16 @@ begin
       wbInteger('Dodge % Chance', itU8).SetDefaultNativeValue(75),
       wbInteger('Left/Right % Chance', itU8).SetDefaultNativeValue(50),
       wbUnused(2),
-      wbFloat('Dodge L/R Timer (min)').SetDefaultNativeValue(0.5),
-      wbFloat('Dodge L/R Timer (max)').SetDefaultNativeValue(1.5),
-      wbFloat('Dodge Forward Timer (min)').SetDefaultNativeValue(0.5),
-      wbFloat('Dodge Forward Timer (max)').SetDefaultNativeValue(1),
-      wbFloat('Dodge Back Timer Min').SetDefaultNativeValue(0.25),
-      wbFloat('Dodge Back Timer Max').SetDefaultNativeValue(0.75),
-      wbFloat('Idle Timer min').SetDefaultNativeValue(0.5),
-      wbFloat('Idle Timer max').SetDefaultNativeValue(1.5),
+      wbStruct('Dodge', [
+        wbFloat('L/R Timer Min').SetDefaultNativeValue(0.5),
+        wbFloat('L/R Timer Max').SetDefaultNativeValue(1.5),
+        wbFloat('Forward Timer Min').SetDefaultNativeValue(0.5),
+        wbFloat('Forward Timer Max').SetDefaultNativeValue(1),
+        wbFloat('Back Timer Min').SetDefaultNativeValue(0.25),
+        wbFloat('Back Timer Max').SetDefaultNativeValue(0.75)
+      ]),
+      wbFloat('Idle Timer Min').SetDefaultNativeValue(0.5),
+      wbFloat('Idle Timer Max').SetDefaultNativeValue(1.5),
       wbInteger('Block % Chance', itU8).SetDefaultNativeValue(30),
       wbInteger('Attack % Chance', itU8).SetDefaultNativeValue(40),
       wbUnused(2),
@@ -2164,16 +2199,18 @@ begin
       wbFloat('Hand-To-Hand Bonus to Attack').SetDefaultNativeValue(5),
       wbInteger('Power Attack % Chance', itU8).SetDefaultNativeValue(25),
       wbUnused(3),
-      wbFloat('Recoil/Stagger Bonus to Power').SetDefaultNativeValue(5),
+      wbFloat('Recoil/Stagger Bonus to Power Attack').SetDefaultNativeValue(5),
       wbFloat('Unconscious Bonus to Power Attack').SetDefaultNativeValue(5),
-      wbInteger('Power Attack - Normal', itU8).SetDefaultNativeValue(20),
-      wbInteger('Power Attack - Forward', itU8).SetDefaultNativeValue(20),
-      wbInteger('Power Attack - Back', itU8).SetDefaultNativeValue(20),
-      wbInteger('Power Attack - Left', itU8).SetDefaultNativeValue(20),
-      wbInteger('Power Attack - Right', itU8).SetDefaultNativeValue(20),
+      wbStruct('Power Attack', [
+        wbInteger('Normal', itU8).SetDefaultNativeValue(20),
+        wbInteger('Forward', itU8).SetDefaultNativeValue(20),
+        wbInteger('Back', itU8).SetDefaultNativeValue(20),
+        wbInteger('Left', itU8).SetDefaultNativeValue(20),
+        wbInteger('Right', itU8).SetDefaultNativeValue(20)
+      ]),
       wbUnused(3),
-      wbFloat('Hold Timer (min)').SetDefaultNativeValue(0.5),
-      wbFloat('Hold Timer (max)').SetDefaultNativeValue(1.5),
+      wbFloat('Hold Timer Min').SetDefaultNativeValue(0.5),
+      wbFloat('Hold Timer Max').SetDefaultNativeValue(1.5),
       wbInteger('Flags', itU8,
         wbFlags([
           {0} 'Advanced',
@@ -2202,31 +2239,38 @@ begin
     wbStruct(CSAD, 'Advanced', [
       wbFloat('Dodge Fatigue Mod Mult').SetDefaultNativeValue(-20),
       wbFloat('Dodge Fatigue Mod Base'),
-      wbFloat('Encumb. Speed Mod Base').SetDefaultNativeValue(-110),
-      wbFloat('Encumb. Speed Mod Mult').SetDefaultNativeValue(1),
-      wbFloat('Dodge While Under Attack Mult').SetDefaultNativeValue(1),
-      wbFloat('Dodge Not Under Attack Mult').SetDefaultNativeValue(0.75),
-      wbFloat('Dodge Back While Under Attack Mult').SetDefaultNativeValue(1),
-      wbFloat('Dodge Back Not Under Attack Mult').SetDefaultNativeValue(0.7),
-      wbFloat('Dodge Forward While Attacking Mult').SetDefaultNativeValue(1),
-      wbFloat('Dodge Forward Not Attacking Mult').SetDefaultNativeValue(0.5),
-      wbFloat('Block Skill Modifier Mult').SetDefaultNativeValue(20),
-      wbFloat('Block Skill Modifier Base'),
-      wbFloat('Block While Under Attack Mult').SetDefaultNativeValue(2),
-      wbFloat('Block Not Under Attack Mult').SetDefaultNativeValue(1),
-      wbFloat('Attack Skill Modifier Mult').SetDefaultNativeValue(20),
-      wbFloat('Attack Skill Modifier Base'),
-      wbFloat('Attack While Under Attack Mult').SetDefaultNativeValue(0.75),
-      wbFloat('Attack Not Under Attack Mult').SetDefaultNativeValue(1),
-      wbFloat('Attack During Block Mult').SetDefaultNativeValue(0.5),
-      wbFloat('Power Att. Fatigue Mod Base').SetDefaultNativeValue(5),
-      wbFloat('Power Att. Fatigue Mod Mult').SetDefaultNativeValue(-10)
+      wbFloat('Encumbered Speed Mod Base').SetDefaultNativeValue(-110),
+      wbFloat('Encumbered Speed Mod Mult').SetDefaultNativeValue(1),
+      wbStruct('Dodge', [
+        wbFloat('While Under Attack Mult').SetDefaultNativeValue(1),
+        wbFloat('Not Under Attack Mult').SetDefaultNativeValue(0.75),
+        wbFloat('Back While Under Attack Mult').SetDefaultNativeValue(1),
+        wbFloat('Back Not Under Attack Mult').SetDefaultNativeValue(0.7),
+        wbFloat('Forward While Attacking Mult').SetDefaultNativeValue(1),
+        wbFloat('Forward Not Attacking Mult').SetDefaultNativeValue(0.5)
+      ]),
+      wbStruct('Block', [
+        wbFloat('Skill Modifier Mult').SetDefaultNativeValue(20),
+        wbFloat('Skill Modifier Base'),
+        wbFloat('While Under Attack Mult').SetDefaultNativeValue(2),
+        wbFloat('Not Under Attack Mult').SetDefaultNativeValue(1)
+      ]),
+      wbStruct('Attack', [
+        wbFloat('Skill Modifier Mult').SetDefaultNativeValue(20),
+        wbFloat('Skill Modifier Base'),
+        wbFloat('While Under Attack Mult').SetDefaultNativeValue(0.75),
+        wbFloat('Not Under Attack Mult').SetDefaultNativeValue(1),
+        wbFloat('During Block Mult').SetDefaultNativeValue(0.5)
+      ]),
+      wbFloat('Power Attack Fatigue Mod Base').SetDefaultNativeValue(5),
+      wbFloat('Power Attack Fatigue Mod Mult').SetDefaultNativeValue(-10)
     ])
   ]);
 
   wbRecord(DIAL, 'Dialog Topic', [
     wbEDID,
-    wbRArrayS('Quests', wbFormIDCkNoReach(QSTI, 'Quest', [QUST], False, cpBenign)),
+    wbQSTI,
+    wbQSTR,
     wbFULL,
     wbInteger(DATA, 'Type', itU8, wbDialogueTypeEnum).SetRequired,
     wbINOM,
@@ -2241,17 +2285,17 @@ begin
     wbFULL,
     wbTexturedModel('Model', [MODL, MODB, MODT], []),
     wbSCRI,
-    wbFormIDCk(SNAM, 'Open sound', [SOUN]),
-    wbFormIDCk(ANAM, 'Close sound', [SOUN]),
-    wbFormIDCk(BNAM, 'Loop sound', [SOUN]),
+    wbFormIDCk(SNAM, 'Open Sound', [SOUN]),
+    wbFormIDCk(ANAM, 'Close Sound', [SOUN]),
+    wbFormIDCk(BNAM, 'Loop Sound', [SOUN]),
     wbInteger(FNAM, 'Flags', itU8,
       wbFlags([
-        {0} 'Oblivion gate',
-        {1} 'Automatic door',
+        {0} 'Oblivion Gate',
+        {1} 'Automatic Door',
         {2} 'Hidden',
-        {3} 'Minimal use'
+        {3} 'Minimal Use'
       ])).SetRequired,
-    wbRArrayS('Random teleport destinations',
+    wbRArrayS('Random Teleport Destinations',
       wbFormIDCk(TNAM, 'Destination', [CELL, WRLD]))
   ]);
 
@@ -2269,52 +2313,60 @@ begin
         ], False, 6))
       ).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbUnused(3),
-      wbInteger('Membrane Shader - Source Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(5),
-      wbInteger('Membrane Shader - Blend Operation', itU32, wbBlendOpEnum).SetDefaultNativeValue(1),
-      wbInteger('Membrane Shader - Z Test Function', itU32, wbZTestFuncEnum).SetDefaultNativeValue(3),
-      wbByteColors('Fill/Texture Effect - Color'),
-      wbFloat('Fill/Texture Effect - Alpha Fade In Time'),
-      wbFloat('Fill/Texture Effect - Full Alpha Time'),
-      wbFloat('Fill/Texture Effect - Alpha Fade Out Time'),
-      wbFloat('Fill/Texture Effect - Presistent Alpha Ratio'),
-      wbFloat('Fill/Texture Effect - Alpha Pulse Amplitude'),
-      wbFloat('Fill/Texture Effect - Alpha Pulse Frequency').SetDefaultNativeValue(1),
-      wbFloat('Fill/Texture Effect - Texture Animation Speed (U)'),
-      wbFloat('Fill/Texture Effect - Texture Animation Speed (V)'),
-      wbFloat('Edge Effect - Fall Off').SetDefaultNativeValue(1),
-      wbByteColors('Edge Effect - Color'),
-      wbFloat('Edge Effect - Alpha Fade In Time'),
-      wbFloat('Edge Effect - Full Alpha Time'),
-      wbFloat('Edge Effect - Alpha Fade Out Time'),
-      wbFloat('Edge Effect - Persistent Alpha Ratio'),
-      wbFloat('Edge Effect - Alpha Pulse Amplitude'),
-      wbFloat('Edge Effect - Alpha Pusle Frequence').SetDefaultNativeValue(1),
+      wbStruct('Membrane Shader', [
+        wbInteger('Source Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(5),
+        wbInteger('Blend Operation', itU32, wbBlendOpEnum).SetDefaultNativeValue(1),
+        wbInteger('Z Test Function', itU32, wbZTestFuncEnum).SetDefaultNativeValue(3)
+      ]),
+      wbStruct('Fill/Texture Effect', [
+        wbByteColors('Color'),
+        wbFloat('Alpha Fade In Time'),
+        wbFloat('Full Alpha Time'),
+        wbFloat('Alpha Fade Out Time'),
+        wbFloat('Persistent Alpha Ratio'),
+        wbFloat('Alpha Pulse Amplitude'),
+        wbFloat('Alpha Pulse Frequency').SetDefaultNativeValue(1),
+        wbFloat('Texture Animation Speed (U)'),
+        wbFloat('Texture Animation Speed (V)')
+      ]),
+      wbStruct('Edge Effect', [
+        wbFloat('Fall Off').SetDefaultNativeValue(1),
+        wbByteColors('Color'),
+        wbFloat('Alpha Fade In Time'),
+        wbFloat('Full Alpha Time'),
+        wbFloat('Alpha Fade Out Time'),
+        wbFloat('Persistent Alpha Ratio'),
+        wbFloat('Alpha Pulse Amplitude'),
+        wbFloat('Alpha Pusle Frequence').SetDefaultNativeValue(1)
+      ]),
       wbFloat('Fill/Texture Effect - Full Alpha Ratio').SetDefaultNativeValue(1),
       wbFloat('Edge Effect - Full Alpha Ratio').SetDefaultNativeValue(1),
       wbInteger('Membrane Shader - Dest Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(6),
-      wbInteger('Particle Shader - Source Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(5),
-      wbInteger('Particle Shader - Blend Operation', itU32, wbBlendOpEnum).SetDefaultNativeValue(1),
-      wbInteger('Particle Shader - Z Test Function', itU32, wbZTestFuncEnum).SetDefaultNativeValue(4),
-      wbInteger('Particle Shader - Dest Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(6),
-      wbFloat('Particle Shader - Particle Birth Ramp Up Time'),
-      wbFloat('Particle Shader - Full Particle Birth Time'),
-      wbFloat('Particle Shader - Particle Birth Ramp Down Time'),
-      wbFloat('Particle Shader - Full Particle Birth Ratio').SetDefaultNativeValue(1),
-      wbFloat('Particle Shader - Persistant Particle Birth Ratio').SetDefaultNativeValue(1),
-      wbFloat('Particle Shader - Particle Lifetime').SetDefaultNativeValue(1),
-      wbFloat('Particle Shader - Particle Lifetime +/-'),
-      wbFloat('Particle Shader - Initial Speed Along Normal'),
-      wbFloat('Particle Shader - Acceleration Along Normal'),
-      wbFloat('Particle Shader - Initial Velocity #1'),
-      wbFloat('Particle Shader - Initial Velocity #2'),
-      wbFloat('Particle Shader - Initial Velocity #3'),
-      wbFloat('Particle Shader - Acceleration #1'),
-      wbFloat('Particle Shader - Acceleration #2'),
-      wbFloat('Particle Shader - Acceleration #3'),
-      wbFloat('Particle Shader - Scale Key 1').SetDefaultNativeValue(1),
-      wbFloat('Particle Shader - Scale Key 2').SetDefaultNativeValue(1),
-      wbFloat('Particle Shader - Scale Key 1 Time'),
-      wbFloat('Particle Shader - Scale Key 2 Time').SetDefaultNativeValue(1),
+      wbStruct('Particle Shader', [
+        wbInteger('Source Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(5),
+        wbInteger('Blend Operation', itU32, wbBlendOpEnum).SetDefaultNativeValue(1),
+        wbInteger('Z Test Function', itU32, wbZTestFuncEnum).SetDefaultNativeValue(4),
+        wbInteger('Dest Blend Mode', itU32, wbBlendModeEnum).SetDefaultNativeValue(6),
+        wbFloat('Particle Birth Ramp Up Time'),
+        wbFloat('Full Particle Birth Time'),
+        wbFloat('Particle Birth Ramp Down Time'),
+        wbFloat('Full Particle Birth Ratio').SetDefaultNativeValue(1),
+        wbFloat('Persistant Particle Birth Ratio').SetDefaultNativeValue(1),
+        wbFloat('Particle Lifetime').SetDefaultNativeValue(1),
+        wbFloat('Particle Lifetime +/-'),
+        wbFloat('Initial Speed Along Normal'),
+        wbFloat('Acceleration Along Normal'),
+        wbFloat('Initial Velocity #1'),
+        wbFloat('Initial Velocity #2'),
+        wbFloat('Initial Velocity #3'),
+        wbFloat('Acceleration #1'),
+        wbFloat('Acceleration #2'),
+        wbFloat('Acceleration #3'),
+        wbFloat('Scale Key 1').SetDefaultNativeValue(1),
+        wbFloat('Scale Key 2').SetDefaultNativeValue(1),
+        wbFloat('Scale Key 1 Time'),
+        wbFloat('Scale Key 2 Time').SetDefaultNativeValue(1)
+      ]),
       wbByteColors('Color Key 1 - Color'),
       wbByteColors('Color Key 2 - Color'),
       wbByteColors('Color Key 3 - Color'),
@@ -2462,7 +2514,7 @@ begin
   wbRecord(HAIR, 'Hair', [
     wbEDID.SetRequired,
     wbFULL,
-    wbTexturedModel('Skeleton', [MODL, MODB, MODT], []),
+    wbTexturedModel('Model', [MODL, MODB, MODT], []),
     wbString(ICON, 'Texture').SetRequired,
     wbInteger(DATA, 'Flags', itU8,
       wbFlags([
@@ -2745,7 +2797,7 @@ begin
     .SetAfterLoad(wbLVLAfterLoad);
 
   wbRecord(MGEF, 'Magic Effect', [
-    wbStringMgefCode(EDID, 'Magic Effect Code').SetRequired,
+    wbStringMgefCode(EDID, 'Magic Effect Code', 4).SetRequired,
     wbStruct(OBME, 'Oblivion Magic Extender', [
       wbInteger('Record Version', itU8),
       wbOBMEVersion,
@@ -2764,7 +2816,7 @@ begin
           20, 'ParamFlagD',
           30, 'Hidden'
         ], False, 31))),
-      wbByteArray('ParamB', 4),
+      wbByteArray('Param B', 4), //Needs a union based on Handler.
       wbUnused($1C)
     ]).SetDontShow(wbOBMEDontShow),
     wbString(EDDX, 'EditorID').SetDontShow(wbEDDXDontShow),
@@ -2802,7 +2854,7 @@ begin
       ).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbFloat('Base cost'),
       wbUnion('Assoc. Item', wbMGEFFAssocItemDecider, [
-        wbFormIDCk('Unused', [NULL]),
+        wbByteArray('Param A', 4).SetDontShow(wbOBMEDontShow), //Needs a union based on Handler.
         wbFormIDCk('Assoc. Weapon', [WEAP]),
         wbFormIDCk('Assoc. Armor', [ARMO, NULL{?}]),
         wbFormIDCk('Assoc. Creature', [CREA, LVLC, NPC_]),
@@ -2811,15 +2863,16 @@ begin
       wbInteger('Magic School', itU32, wbMagicSchoolEnum),
       wbInteger('Resist value', itS32,
         wbEnum([], [
-          -1, 'None',
-          61, 'Resist Fire',
-          62, 'Resist Frost',
-          63, 'Resist Disease',
-          64, 'Resist Magic',
-          65, 'Resist Normal Weapons',
-          66, 'Resist Paralysis',
-          67, 'Resist Poison',
-          68, 'Resist Shock'
+          -1,  'None',
+          61,  'Resist Fire',
+          62,  'Resist Frost',
+          63,  'Resist Disease',
+          64,  'Resist Magic',
+          65,  'Resist Normal Weapons',
+          66,  'Resist Paralysis',
+          67,  'Resist Poison',
+          68,  'Resist Shock',
+          255, 'None (OBME)'
         ])),
       wbInteger('Counter Effect Count', itU16), //!!! must be updated automatically when ESCE length changes!
       wbUnused(2),
@@ -2874,7 +2927,7 @@ begin
     wbFlags(wbFlagsList([
       10, 'Quest Item',
       18, 'Compressed',
-      19, 'Unknown 19'
+      19, 'Spawns Dead'
     ])), [
     wbEDID,
     wbFULL,
@@ -3305,7 +3358,7 @@ begin
     wbOwnership([XLOC]),
     wbXESP,
     wbFormIDCk(XTRG, 'Target', [ACHR, ACRE, REFR], True),
-    wbStruct(XSED, 'SpeedTree', [
+    wbStruct(XSED, 'Speed Tree', [
       wbInteger('Seed', itU8),
       wbUnused(0)
     ]),
@@ -3319,7 +3372,7 @@ begin
     wbInteger(XLCM, 'Level Modifier', itS32),
     wbFormIDCk(XRTM, 'Reference Teleport Marker', [REFR]),
     wbActionFlag,
-    wbInteger(XCNT, 'Count', itS32),
+    wbInteger(XCNT, 'Count', itU32),
     wbRStruct('Map Marker', [
       wbEmpty(XMRK, 'Map Marker Data'),
       wbInteger(FNAM, 'Map Flags', itU8,
@@ -3524,7 +3577,7 @@ begin
 
   wbRecord(SOUN, 'Sound', [
     wbEDID,
-    wbString(FNAM, 'Sound FileName'),
+    wbString(FNAM, 'Sound Filename'),
     wbRUnion('Sound Data', [
       wbStruct(SNDX, 'Sound Data', wbSoundDataMembers, cpNormal, True, nil, 6),
       wbStruct(SNDD, 'Sound Data', wbSoundDataMembers, cpNormal, True, nil, 6)

--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -5861,7 +5861,7 @@ begin
                 GroupType := 8;
               end;
             end else
-              if (Rec.Signature = 'NAM0') or (Rec.Signature = 'MVRF') then
+              if Rec.Signature = 'NAM0' then
                 GroupType := 9;
           end else
             flProgress(Rec.Name + ' processed');
@@ -10192,7 +10192,7 @@ begin
 
   CurrentPtr := GetDataBasePtr;
   while NativeUInt(CurrentPtr) < NativeUInt(dcDataEndPtr) do begin
-    if (IsTES3Cell or (FRMRCount > 0)) and ((PwbSignature(CurrentPtr)^ = 'FRMR') or (PwbSignature(CurrentPtr)^ = 'NAM0') or (PwbSignature(CurrentPtr)^ = 'MVRF') or (PwbSignature(CurrentPtr)^ = 'CNDT')) then begin
+    if (IsTES3Cell or (FRMRCount > 0)) and ((PwbSignature(CurrentPtr)^ = 'FRMR') or (PwbSignature(CurrentPtr)^ = 'NAM0') or (PwbSignature(CurrentPtr)^ = 'MVRF')) then begin
       if dcEndPtr = dcDataEndPtr then
         dcEndPtr := CurrentPtr;
       dcDataEndPtr := CurrentPtr;

--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -4730,8 +4730,9 @@ function wbStringEnumSummary(const aNames       : array of string;
                                                 : IwbStringDefFormater; overload;
 
 
-function wbDiv(aValue : Integer)
-                      : IwbIntegerDefFormater;
+function wbDiv(aValue     : Integer;
+               aPrecision : Integer = wbFloatDigits)
+                          : IwbIntegerDefFormater;
 function wbMul(aValue : Integer)
                       : IwbIntegerDefFormater;
 function wbCallback(const aToStr : TwbIntToStrCallback;
@@ -7675,9 +7676,10 @@ type
   TwbDivDef = class(TwbIntegerDefFormater)
   private
     ddValue: Integer;
+    ddPrecision: Integer;
   protected
     constructor Clone(const aSource: TwbDef); override;
-    constructor Create(aValue: Integer);
+    constructor Create(aValue: Integer; aPrecision: Integer);
 
     {---IwbIntegerDefFormater---}
     function ToString(aInt: Int64; const aElement: IwbElement; aForSummary: Boolean): string; override;
@@ -8137,14 +8139,14 @@ begin
 end;
 
 function wbStringMgefCode(const aSignature : TwbSignature;
-                    const aName      : string;
-                          aSize      : Integer = 0;
-                          aPriority  : TwbConflictPriority = cpNormal;
-                          aRequired  : Boolean = False;
-                          aDontShow  : TwbDontShowCallback = nil;
-                          aAfterSet  : TwbAfterSetCallback = nil;
-                          aGetCP     : TwbGetConflictPriority = nil)
-                                     : IwbSubRecordWithBaseStringDef; overload;
+                          const aName      : string;
+                                aSize      : Integer = 0;
+                                aPriority  : TwbConflictPriority = cpNormal;
+                                aRequired  : Boolean = False;
+                                aDontShow  : TwbDontShowCallback = nil;
+                                aAfterSet  : TwbAfterSetCallback = nil;
+                                aGetCP     : TwbGetConflictPriority = nil)
+                                           : IwbSubRecordWithBaseStringDef; overload;
 begin
   Result := wbSubRecord(aSignature, aName, wbStringMgefCode('', aSize, aPriority), nil, aAfterSet, aPriority, aRequired, False, aDontShow, aGetCP) as IwbSubRecordWithBaseStringDef;
 end;
@@ -9991,10 +9993,11 @@ begin
   Result := TwbEnumDef.Create(True, aNames, aSparseNames);
 end;
 
-function wbDiv(aValue : Integer)
-                      : IwbIntegerDefFormater;
+function wbDiv(aValue     : Integer;
+               aPrecision : Integer = wbFloatDigits)
+                          : IwbIntegerDefFormater;
 begin
-  Result := TwbDivDef.Create(aValue);
+  Result := TwbDivDef.Create(aValue, aPrecision);
 end;
 
 function wbMul(aValue : Integer)
@@ -19134,12 +19137,13 @@ end;
 constructor TwbDivDef.Clone(const aSource: TwbDef);
 begin
   with aSource as TwbDivDef do
-    Self.Create(ddValue).AfterClone(aSource);
+    Self.Create(ddValue, ddPrecision).AfterClone(aSource);
 end;
 
-constructor TwbDivDef.Create(aValue: Integer);
+constructor TwbDivDef.Create(aValue: Integer; aPrecision: Integer);
 begin
   ddValue := aValue;
+  ddPrecision := aPrecision;
   inherited Create;
 end;
 
@@ -19158,7 +19162,7 @@ end;
 
 function TwbDivDef.ToEditValue(aInt: Int64; const aElement: IwbElement): string;
 begin
-  Result := FloatToStrF(aInt / ddValue, ffFixed, 99, wbFloatDigits);
+  Result := FloatToStrF(aInt / ddValue, ffFixed, 99, ddPrecision);
 end;
 
 function TwbDivDef.ToSortKey(aInt: Int64; const aElement: IwbElement): string;
@@ -19170,7 +19174,7 @@ end;
 
 function TwbDivDef.ToString(aInt: Int64; const aElement: IwbElement; aForSummary: Boolean): string;
 begin
-  Result := FloatToStrF(aInt / ddValue, ffFixed, 99, wbFloatDigits);
+  Result := FloatToStrF(aInt / ddValue, ffFixed, 99, ddPrecision);
   Used(aElement, Result);
 end;
 


### PR DESCRIPTION
Upload for Robert to sift through for anything useful. It's probably all trash. There is a bunch of overlap. Might periodically update as my hand allows. This is verbose. Obtuse even. *Indicates a note.

TES3
-DESC is now displayed as the name for MGEFs and SKILs.
-NAME is now displayed as the name for SCCRs.
-Changed GridCellToFormID to wbGridCellToFormID to match the naming convention.
-Replaced the 'Record Flag' definition with an empty one. Not every Form Type used all the flags.
-Spacing adjustments. *1
-Fixed grammar.
-DELE now says 'True' instead of 'Deleted.'
-Added more common definitions. DESC, Effects, ITEX, Items, Packages, ans Spells.
-Added SetRequired on everything that was added to new Form Types by default in the CS. *2
-All mentions of 'Service Flags' are now 'Buy/Sell Service Flags.' *1
-Added SetDefaultNativeValue to everything that had a non-zero value when initialized in the CS. *2
-Moved 'Biped Objects' enumerator to it's only use instance.
-Added SetSummaryKey on many applicable definition structs to match the other game definitions.
-Added Sort Key Structs to applicable structs.
-Added Sorted Arrays to applicable arrays.
-Added AfterSet to fix forwarding bug in wbString. *3
-Replaced various uses of wbVec3 for Position/Rotation to just wbVec3PosRot when both were present.
-Each form type's 'Record Flags' defines the extra flags specific to that Form Type. *2
-Changed many instances of itS32 to itU32 when they were used for value, health, stats, etc. *4
-All mentions of 'Enchanting Charge' are now 'Enchantment Charge.'
-Added any missing wbCollapseFlags for BitMask based definitions.

\TES3 - Added AfterLoad to set the ESM flag on the record header. *5
\TES3\MAST - Renamed to 'Master Filename.'
\ALCH - Reverted name back to 'Potion.'
\ALCH\ALDT - Renamed to just 'Data' and 'Value' is now 'Potion Value.'
\APPA - Reverted name back to 'Alchemical Apparatus.'
\BODY\BYDT - Changed 'Part' to 'Body Part.'
\BODY - Set Summary Key to 'Model.'
\BOOK\BKDT - Renamed to just 'Data,' and 'Is Scroll' is just 'Scroll.'
\BOOK\TEXT - Updated to include cpTranslate.
\BSGN\FNAM - SetRequired False. *6
\BSGN\TNAM - Is now 'Constellation Filename.'
\CELL\DATA - 'Grid' is now hidden when viewing Interior Cells. *7
\CELL\NAME - Renamed to 'Location.'
\CELL - Added AfterLoad to move the value in INTV to WHGT.
\CELL - Added SetDontShow to INTV, NAM5, WHGT, and AMBI based on the 'Is Interior' bit.
\DIAL\DATA - Added Union to account for the different version (1.2 and 1.3) types. *8
\DIAL - Set Summary Key to 'Dialog Type.'
\DOOR\FNAM - SetRequired False. *6
\ENCH\ENDT - Updated the enumerator for 'Auto Calculate.' *9
\FACT\FADT - Completely restructured and renamed the definition to be more accurate and readable.
\FACT - Added ToStr to Faction Reactions for collapsed summary. *10
\GLOB\FNAM - Removed Global Union.
\GLOB - Added AfterLoad to account for several baked in errors in the Morrowind.esm. *11
\GLOB - Set Summary Key to FLTV.
\GMST - Changed names on the 'Value' signatures to be less awkward looking.
\GMST - Set Summary Key to 'Value.'
\INFO\DATA - Changed 'Gender' to 'Sex' to match the Construction Set and other games. *12
\INFO\ONAM - Updated comment for valid assignable form types.
\INFO\FNAM - Changed name to be less stilted.
\INFO\ANAM - Changed name to be less stilted.
\INFO\SCVR - Redid the entire definition. *13
\INFO - Moved 'Quest Data' struct to between 'Conditions' and BNAM.' *14
\INGR\IRDT - Vastly improved the definition with the use of an AfterLoad. *15
\LAND\VNML - Updated the definition to match the other game definitions.
\LAND\WNAM - Changed to 'World Map Colors.'
\LAND\VCLR - Now uses a special wbByteColors.
\LEVC\DATA - Renamed to simply 'Flags.'
\LEVC - Added SetCountPath for INDX.
\LEVI\DATA - Renamed to simply 'Flags.'
\LEVI - Added SetCountPath for INDX.
\LIGH\LHDT - 'Radius' is an Integer, not a float.
\LIGH\SNAM - Renamed to 'Looping Sound.'
\LTEX - Set Summary Key to 'Texture Filename.'
\MGEF\INDX - Updated the Magicka specific MGEF in the enumerator to actually say 'Magicka.' *16
\MGEF\MEDT - Removed runtime only flags from the list.
\MGEF - Added special wbByteColors for 'Color.'
\NPC_\NPDT - Optimized the union to run off the signature and not a struct.
\PGRD\NAME - Renamed to just 'Location.'
\PGRD\PGRP - Renamed to just 'Points' to match TES4 and added special wbVec3Pos for 'Position.'
\PRGD\PGRC - Renamed to 'Point-to-Point Connections' to match TES4.
\REFR - Renamed to 'Placed Object.'
\REFR\CNDT - Renamed to 'New Cell Owner.' *7
\REFR\UNAM - Now says 'True' instead of 'Blocked.'
\REFR\INTV - Renamed to 'Health/Uses Left.'
\REFR\DODT - Struct renamed to 'Teleport Destination' and the signature to Position/Rotation.
\REFR - Added AfterLoad to set, if present, the value of DELE to 0. *17
\REGN\CNAM - Renamed to 'Region Map Color.'
\SCPT\SCHD - 'Script Data Size' is now 'Compiled Size.'
\SCPT\SCDT - Now show the number of lines in the script for the record Name. Thank you Zilav.
\SKIL\SKDT - 'Attribute' is now 'Governing Attribute' and added a Skill decider for 'Actions.' *18
\SOUN\DATA - Added a parameter to wbDiv to limit the number of decimals the result has. *19
\SSCR - Added AfterLoad to set, if present, the value of DELE to 0. *17

TES4
-Started spacing adjustments. *1
-Added None(6) to Magic School enumerator for Oblivion Magic Extender.
-Started fixing grammar.
-Left note about adding a union for Effects\...\Visual Effect Code. It can be either 0 or 4 bytes.
-Started decoding bits for Effects\...\Override Flags & Flags. *20
-Changed Effects\...\Unknown to a wbByteArray with 16 bytes.

\TES4\OFST - Decoded as Offset Load Order. It is entirely unused and set to be ignored.
\TES4\DELE - Tentatively decoded as Version Control. It appears unused and set to be ignored. *21
\APPA\DATA - Added decimal limit to 'Weight' and 'Quality.'
\BSGN\ICON - Changed to 'Constellation Filename.'
\CLAS\ICON - Changed to 'Image Filename'
\CREA - Bit 19 for 'Record Flags' is 'Spawns Dead.'
\CSTY\CSTD - Restructured the definition to lump as much together as possible to be cleaner looking.
\CSTY\CSAD - Restructured the definition to lump as much together as possible to be cleaner looking.
\DIAL\QSTI - Replaced with a common definition 'Associated Quests.'
\DIAL\QSTR - Decoded as Removed Quests. *22
\EFSH\DATA - Restructured the definition to lump as much together as possible to be cleaner looking.
\HAIR\MODL - Changed name to 'Model.'
\MGEF\EDID - Added size to the definition. *23
\MGEF\OBME - Added note about using a union based on the handler.
\MGEF\DATA - Updated 'Unused' in 'Associated Item' to a wbByteArray 'Param A' with 4 bytes. *24
\NPC_ - Bit 19 for 'Record Flags' is 'Spawns Dead.'
\REFR\XCNT - Changed to an unsigned integer.

FO3
\DIAL\QSTI - Replaced with a common definition 'Associated Quests.'
\DIAL\QSTR - Replaced with a common definition 'Removed Quests.'

SF1
-Fixed a spelling error in Package Flags.

Other
-Removed unnecessary condition in an if statement related to pulling REFR out of CELL in Morrowind. (Line: 10195)

-Fixed a massive error I made when accounting for MVRF. An if statement incorrectly looked for 'MVRF' when it didn't need to, resulting in xEdit moving all REFR in a CELL with an MVRF to the temporary group. (Line: 5864)

-I discovered a huge error for TES3 that has been around since before I started decoding it. INFOs can share the same INAM value, but across different DIAL. When you load just the Morrowind.esm and do a conflict filter you'll see them. It looks like mostly copy pasted INFOs with slight changes which might explain why they share the same INAM. The INFOs with shared INAMs appear as separate INFOs in the Construction Set. None have appeared in the same DIAL.

Notes
*1 Looks like Robert and I had the same idea but did it differently. For wbServiceFlags, I updated the Apparatus to Alchemical Apparatus and added Repair for Morrowind. Spacing changes were also made to wbStringMGEFCode.

*2 I didn't think to keep any of the files I created for testing for others to view.

*3 When used inside a member definition or for a summary key, xEdit fails to forward a sized string leaving all the junk found after the terminating zero. This is a stop gap because I don't know enough to mess with that bit of xEdit.

*4 I originally went with itS32 because the Construction Set only allowed values between 0 and the signed maximum. In hindsight it made no sense to do that because negative values are not allowed. This was a quick edit after seeing Robert had done the same.

*5 Morrowind saves the file flags in the HEDR of TES3. This simply makes <ESM> appear for cosmetics.

*6 If this is not explicitly set, BSGN and DOOR with an empty/no FNAM fail to display correctly. I have no clue why, it drove me nuts. This was my solution.

*7 Never got around to grouping Interior and Exterior Cells into their own groups, but that requires more interface/implementation editing than I wanted to do at the time. I had done it for MVRF but removed those changes because I misunderstood why MVRF were moved in the CELL's data. They have to be persistent or else the game will not display them in the correct location. MVRF aren't actually moved to the new CELL they now physically exist in, so CNDT just points to the new CELL to group it into the correct CELL for the Construction Set.

*8 Should probably be reverted since it was fine before.

*9 Noticed Robert updated it too but differently. Are constant effects always auto calculated even though the Construction Set says No?

*10 I tried to modify wbFactionRelationToStr to handle Morrowind's format but it didn't work so I reverted the changes to come back to later. I did change instances of Rank to Relation because it annoyed me.

*11 In the Construction Set, it shows 0 for the affected records and they only appear on short based GLOB.

*12 Updated wbSexEnum so it now only displays 'None' for Morrowind and not in every game.

*13 I had noticed the values for what type of function in the comments I had left the first time and redid it. I completed it based on Robert's PR. Its not as in depth as his and done a bit differently but works for what I wanted originally. Removed comments not related to valid assignable form types.

*14 Some how the folks at Tamerial Rebuilt managed to get functions on Journals, which, as far as I was aware, is not possible in the Construction Set. But the Construction Set loads them just fine and saves them the same way. Also, the signatures in the struct now say 'True' instead of 'Yes.'

*15 The Construction Set sometimes sets the right value (-1), other times not (0). It seemed random. So the AfterSet Changes the appropriate fields depending on the MGEF for the effect entry.

*16 Shamelessly taken from Robert's PR. I wanted to update my fork for my own little side project until the next merge.

*17 The value of DELE is random and changes whenever the plugin is saved in the Construction Set for various references with the same base object. The game doesn't seem to care what the value of DELE is, it works all the same. So all DELE now default to 0.

*18 I added the skill decider from the first time but it's less obtuse this time around.

*19 Default is wbFloatDigits.

*20 Its incomplete, mostly just notes.

*21 Only the Oblivion.esm has a non zero value for DELE and the only sensible value for it is FILETIME, which lands in the middle of Oblivion's development. I have not checked it with Version Control in the Construction Set, but I doubt it'll change the value but will follow up on it whenever I do check.

*22 Whenever a quest no longer has any INFOs in a topic it was associated with, it is removed from the topic. In overrides it is moved to QSTR. This looks to be purely a game editor parameter for filtering dialogue based on quests.

*23 Cannot remember why I did it except it fixed an error when loading. Something about EDID not being initialized yet when loading OBME related forms.

*24 Only a temporary change as it should have a union based on if the form is OBME related.