### PR TITLE
FaceGen Standardization

### DIFF
--- a/Core/wbDefinitionsCommon.pas
+++ b/Core/wbDefinitionsCommon.pas
@@ -66,6 +66,7 @@ var
   wbCinematicIMAD: IwbRecordMemberDef;
   wbDATAPosRot: IwbRecordMemberDef;
   wbDMDT: IwbRecordMemberDef;
+  wbFaceGen: IwbRecordMemberDef;
   wbFaction: IwbRecordMemberDef;
   wbFactionRelations: IwbRecordMemberDef;
   wbHEDR: IwbRecordMemberDef;
@@ -7164,6 +7165,20 @@ Can't properly represent that with current record definition methods.
         .IncludeFlag(dfCollapsed, wbCollapseOther)
         .IncludeFlag(dfFastAssign)
         .IncludeFlag(dfNoCopyAsOverride));
+
+  //TES4,FO3,FNV
+  wbFaceGen :=
+    IfThen(wbSimpleRecords,
+      wbRStruct('FaceGen Data', [
+        wbByteArray(FGGS, 'FaceGen Symmetric Geometry', 200).SetRequired,
+        wbByteArray(FGGA, 'FaceGen Asymmetric Geometry', 120).SetRequired,
+        wbByteArray(FGTS, 'FaceGen Symmetric Texture', 200).SetRequired
+      ]).SetRequired,
+      wbRStruct('FaceGen Data', [
+        wbArray(FGGS, 'FaceGen Symmetric Geometry', wbFloat('Bone Morph Key'), 50).SetRequired,
+        wbArray(FGGA, 'FaceGen Asymmetric Geometry', wbFloat('Bone Morph Key'), 30).SetRequired,
+        wbArray(FGTS, 'FaceGen Symmetric Texture', wbFloat('Color Morph Key'), 50).SetRequired
+      ]).SetRequired).IncludeFlag(dfCollapsed, wbCollapseOther);
 end;
 
 end.

--- a/Core/wbDefinitionsFNV.pas
+++ b/Core/wbDefinitionsFNV.pas
@@ -91,8 +91,6 @@ var
   wbEmbeddedScriptReq: IwbRecordMemberDef;
   wbSCRI: IwbSubRecordDef;
   wbSCRIActor: IwbSubRecordDef;
-  wbFaceGen: IwbSubRecordStructDef;
-  wbFaceGenNPC: IwbSubRecordStructDef;
   wbENAM: IwbSubRecordDef;
 //  wbFGGS: IwbSubRecordDef;
   wbXESP: IwbSubRecordDef;
@@ -6950,33 +6948,6 @@ begin
     ], cpNormal, True)
   ]);
 
-  // floats are reported to change faces after copying
-  if True {wbSimpleRecords} then begin
-    wbFaceGen := wbRStruct('FaceGen Data', [
-      wbByteArray(FGGS, 'FaceGen Geometry-Symmetric', 0, cpNormal, True),
-      wbByteArray(FGGA, 'FaceGen Geometry-Asymmetric', 0, cpNormal, True),
-      wbByteArray(FGTS, 'FaceGen Texture-Symmetric', 0, cpNormal, True)
-    ], [], cpNormal, True);
-
-    wbFaceGenNPC := wbRStruct('FaceGen Data', [  // Arrays of 4bytes elements
-      wbByteArray(FGGS, 'FaceGen Geometry-Symmetric', 0, cpNormal, True),
-      wbByteArray(FGGA, 'FaceGen Geometry-Asymmetric', 0, cpNormal, True),
-      wbByteArray(FGTS, 'FaceGen Texture-Symmetric', 0, cpNormal, True)
-    ], [], cpNormal, True, wbActorTemplateUseModelAnimation);
-  end else begin
-    wbFaceGen := wbRStruct('FaceGen Data', [
-      wbArray(FGGS, 'FaceGen Geometry-Symmetric',  wbFloat('Value'), [], cpNormal, True),
-      wbArray(FGGA, 'FaceGen Geometry-Asymmetric', wbFloat('Value'), [], cpNormal, True),
-      wbArray(FGTS, 'FaceGen Texture-Symmetric',   wbFloat('Value'), [], cpNormal, True)
-    ], [], cpNormal, True);
-
-    wbFaceGenNPC := wbRStruct('FaceGen Data', [
-      wbArray(FGGS, 'FaceGen Geometry-Symmetric',  wbFloat('Value'), [], cpNormal, True),
-      wbArray(FGGA, 'FaceGen Geometry-Asymmetric', wbFloat('Value'), [], cpNormal, True),
-      wbArray(FGTS, 'FaceGen Texture-Symmetric',   wbFloat('Value'), [], cpNormal, True)
-    ], [], cpNormal, True, wbActorTemplateUseModelAnimation);
-  end;
-
   wbRecord(NPC_, 'Non-Player Character',
     wbFlags(wbFlagsList([
       10, 'Quest Item',
@@ -7142,7 +7113,7 @@ begin
     wbByteColors(HCLR, 'Hair color').SetRequired.SetDontShow(wbActorTemplateUseModelAnimation),
     wbFormIDCk(ZNAM, 'Combat Style', [CSTY], False, cpNormal, False, wbActorTemplateUseTraits),
     wbInteger(NAM4, 'Impact Material Type', itU32, wbActorImpactMaterialEnum, cpNormal, True, False, wbActorTemplateUseModelAnimation),
-    wbFaceGenNPC,
+    wbFaceGen.SetDontShow(wbActorTemplateUseModelAnimation),
     wbInteger(NAM5, 'Unknown', itU16, nil, cpNormal, True, False, nil, nil, 255),
     wbFloat(NAM6, 'Height', cpNormal, True, 1, -1, wbActorTemplateUseTraits),
     wbFloat(NAM7, 'Weight', cpNormal, True, 1, -1, wbActorTemplateUseTraits)

--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -64,7 +64,6 @@ var
   wbEmbeddedScriptReq: IwbRecordMemberDef;
   wbETYP: IwbRecordMemberDef;
   wbETYPReq: IwbRecordMemberDef;
-  wbFaceGen: IwbRecordMemberDef;
   wbFULL: IwbRecordMemberDef;
   wbFULLReq: IwbRecordMemberDef;
   wbICON: IwbRecordMemberDef;
@@ -3256,12 +3255,6 @@ begin
 
   wbEffectsReq :=
     wbRArray('Effects', wbEffect).SetRequired;
-
-  wbFaceGen := wbRStruct('FaceGen Data', [
-    wbByteArray(FGGS, 'FaceGen Geometry-Symmetric').SetRequired,
-    wbByteArray(FGGA, 'FaceGen Geometry-Asymmetric').SetRequired,
-    wbByteArray(FGTS, 'FaceGen Texture-Symmetric').SetRequired
-  ]).SetRequired;
 
   var wbHeadParts :=
     wbRArrayS('Parts',

--- a/Core/wbDefinitionsTES3.pas
+++ b/Core/wbDefinitionsTES3.pas
@@ -1780,6 +1780,7 @@ begin
 
   wbRecord(MGEF, 'Magic Effect', @wbKnownSubRecordSignaturesINDX, [
     wbInteger(INDX, 'Effect', itU32, wbMagicEffectEnum),
+    wbDeleted,
     wbStruct(MEDT, 'Data', [
       wbInteger('School', itU32,
         wbEnum([
@@ -2215,8 +2216,9 @@ begin
 
   wbRecord(SKIL, 'Skill', @wbKnownSubRecordSignaturesINDX, [
     wbInteger(INDX, 'Name', itU32, wbSkillEnum).SetRequired,
+    wbDeleted,
     wbStruct(SKDT, 'Data', [
-      wbInteger(' Governing Attribute', itS32, wbAttributeEnum),
+      wbInteger('Governing Attribute', itS32, wbAttributeEnum),
       wbInteger('Type', itU32, wbSpecializationEnum),
       wbUnion('Actions', wbSkillDecider, [
         wbStruct('Block', [

--- a/Core/wbDefinitionsTES4.pas
+++ b/Core/wbDefinitionsTES4.pas
@@ -50,7 +50,6 @@ var
   wbDESC: IwbRecordMemberDef;
   wbEDID: IwbRecordMemberDef;
   wbEffects: IwbRecordMemberDef;
-  wbFaceGen: IwbRecordMemberDef;
   wbFULL: IwbRecordMemberDef;
   wbFULLReq: IwbRecordMemberDef;
   wbICON: IwbRecordMemberDef;
@@ -1482,13 +1481,6 @@ begin
             .SetToStr(wbConditionToStr)
             .IncludeFlag(dfCollapsed, wbCollapseConditions)
       ]));
-
-  wbFaceGen :=
-    wbRStruct('FaceGen Data', [
-      wbByteArray(FGGS, 'FaceGen Geometry-Symmetric', 200).SetRequired,
-      wbByteArray(FGGA, 'FaceGen Geometry-Asymmetric', 120).SetRequired,
-      wbByteArray(FGTS, 'FaceGen Texture-Symmetric', 200).SetRequired
-    ]).SetRequired;
 
   {wbOBMEVersion :=
     wbStruct('OBME Version', [


### PR DESCRIPTION
Decoded FGGS/FGGA/FGTS for TES4, FO3, FNV.

Note: The sliders in the official tools simply amplify the effect, the actual data stored in the plugin is just the movement of the morph keys. The EGM/EGT store the associated rigging.

One day I'll decode them. Someday that is not any time soon.

This time I didn't accidentally revert it. Also, changed the collapse flag to "Other."