### PR TITLE
Compare NAVI.

### DIFF
--- a/Core/wbDefinitionsCommon.pas
+++ b/Core/wbDefinitionsCommon.pas
@@ -458,10 +458,14 @@ function wbBelowVersion(aVersion: Integer; const aValue: IwbValueDef): IwbValueD
 function wbFromVersion(aVersion: Integer; const aSignature: TwbSignature; const aValue: IwbValueDef): IwbRecordMemberDef; overload;
 function wbFromVersion(aVersion: Integer; const aValue: IwbValueDef): IwbValueDef; overload;
 
-{>>> Vec3 Defs <<<} //11
+{>>> Vec3 Defs <<<} //12
 function wbVec3(const aName   : string = 'Unknown';
                 const aPrefix : string = '')
                               : IwbValueDef; overload;
+
+function wbVec3IgnoreEmpty(const aName   : string = 'Unknown';
+                           const aPrefix : string = '')
+                                         : IwbValueDef; overload;
 
 function wbVec3(const aSignature : TwbSignature;
                 const aName      : string = 'Unknown';
@@ -5063,7 +5067,7 @@ begin
     ]).IncludeFlag(dfUnionStaticResolve);
 end;
 
-{>>> Vec3 Defs <<<} //11
+{>>> Vec3 Defs <<<} //12
 
 function wbVec3(const aName   : string = 'Unknown';
                 const aPrefix : string = '')
@@ -5074,6 +5078,23 @@ begin
       wbFloat('X'),
       wbFloat('Y'),
       wbFloat('Z')
+    ]).SetSummaryKey([0, 1, 2])
+      .SetSummaryMemberPrefixSuffix(0, aPrefix + '(', '')
+      .SetSummaryMemberPrefixSuffix(2, '', ')')
+      .SetSummaryDelimiter(', ')
+      .IncludeFlag(dfSummaryMembersNoName)
+      .IncludeFlag(dfCollapsed, wbCollapseVec3);
+end;
+
+function wbVec3IgnoreEmpty(const aName   : string = 'Unknown';
+                const aPrefix : string = '')
+                              : IwbValueDef;
+begin
+  Result :=
+    wbStruct(aName, [
+      wbFloat('X', cpNormalIgnoreEmpty),
+      wbFloat('Y', cpNormalIgnoreEmpty),
+      wbFloat('Z', cpNormalIgnoreEmpty)
     ]).SetSummaryKey([0, 1, 2])
       .SetSummaryMemberPrefixSuffix(0, aPrefix + '(', '')
       .SetSummaryMemberPrefixSuffix(2, '', ')')

--- a/Core/wbDefinitionsFNV.pas
+++ b/Core/wbDefinitionsFNV.pas
@@ -5294,49 +5294,49 @@ begin
           wbFlags(wbSparseFlags([
             4, 'Initially Disabled',
             5, 'Is Island'
-          ], False, 6))).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
-        wbFormIDCk('Location', [CELL, WRLD]),
+          ], False, 6)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Location', [CELL, WRLD], false, cpNormalIgnoreEmpty),
         wbStruct('Coordinates', [
-          wbInteger('Grid Y', itS16),
-          wbInteger('Grid X', itS16)
+          wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+          wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
         ]).SetSummaryKey([1, 0])
           .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
           .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
           .SetSummaryDelimiter(', ')
           .IncludeFlag(dfCollapsed, wbCollapsePlacement)
           .IncludeFlag(dfSummaryMembersNoName),
-        wbVec3('Approx Location'),
+        wbVec3IgnoreEmpty('Approx Location'),
         wbUnion('Island Data', wbNAVINVMIDecider, [
           wbStruct('Unused', [wbEmpty('Unused')])
             .SetDontShow(wbNeverShow)
             .IncludeFlag(dfCollapsed, wbCollapseOther),
           wbStruct('Island Data', [
             wbStruct('Navmesh Bounds', [
-              wbVec3('Min'),
-              wbVec3('Max')
+              wbVec3IgnoreEmpty('Min'),
+              wbVec3IgnoreEmpty('Max')
             ]),
-            wbInteger('Vertex Count', itU16),
-            wbInteger('Triangle Count', itU16),
+            wbInteger('Vertex Count', itU16, nil, cpNormalIgnoreEmpty),
+            wbInteger('Triangle Count', itU16, nil, cpNormalIgnoreEmpty),
             wbArray('Vertices',
-              wbVec3('Vertex')
-            ).SetCountPath('Vertex Count', True)
+              wbVec3IgnoreEmpty('Vertex'),
+            -1, nil, cpNormalIgnoreEmpty).SetCountPath('Vertex Count', True)
              .IncludeFlag(dfCollapsed, wbCollapseVertices)
              .IncludeFlag(dfNotAlignable),
             wbArray('Triangles',
               wbStruct('Triangle', [
-                wbInteger('Vertex 0', itU16),
-                wbInteger('Vertex 1', itU16),
-                wbInteger('Vertex 2', itU16)
-              ]).IncludeFlag(dfCollapsed, wbCollapseVertices)
-            ).SetCountPath('Triangle Count', True)
+                wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
+              ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
+            -1, cpNormalIgnoreEmpty).SetCountPath('Triangle Count', True)
              .IncludeFlag(dfCollapsed, wbCollapseVertices)
              .IncludeFlag(dfNotAlignable)
           ]).SetSummaryKey([4])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
         ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbFloat('Preferred %')
-      ]).SetSummaryKeyOnValue([1,2,5])
+        wbFloat('Preferred %', cpNormalIgnoreEmpty)
+      ], cpNormalIgnoreEmpty).SetSummaryKeyOnValue([1,2,5])
         .SetSummaryPrefixSuffixOnValue(1, '', '')
         .SetSummaryPrefixSuffixOnValue(2, 'in ', '')
         .SetSummaryPrefixSuffixOnValue(5, 'is island with ', '')
@@ -5345,10 +5345,10 @@ begin
     wbRArrayS('Navmesh Connections',
       wbStructSK(NVCI, [0], 'Connection', [
         wbFormIDCk('Navmesh', [NAVM]),
-        wbArrayS('Standard', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Door Links', wbFormIDCk('Door', [REFR]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
-      ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+        wbArrayS('Standard', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Door Links', wbFormIDCk('Door', [REFR], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+      ], cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
     ).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
   ]);
 

--- a/Core/wbDefinitionsFO3.pas
+++ b/Core/wbDefinitionsFO3.pas
@@ -4715,49 +4715,49 @@ begin
           wbFlags(wbSparseFlags([
             4, 'Initially Disabled',
             5, 'Is Island'
-          ], False, 6))).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
-        wbFormIDCk('Location', [CELL, WRLD]),
+          ], False, 6)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Location', [CELL, WRLD], false, cpNormalIgnoreEmpty),
         wbStruct('Coordinates', [
-          wbInteger('Grid Y', itS16),
-          wbInteger('Grid X', itS16)
+          wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+          wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
         ]).SetSummaryKey([1, 0])
           .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
           .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
           .SetSummaryDelimiter(', ')
           .IncludeFlag(dfCollapsed, wbCollapsePlacement)
           .IncludeFlag(dfSummaryMembersNoName),
-        wbVec3('Approx Location'),
+        wbVec3IgnoreEmpty('Approx Location'),
         wbUnion('Island Data', wbNAVINVMIDecider, [
           wbStruct('Unused', [wbEmpty('Unused')])
             .SetDontShow(wbNeverShow)
             .IncludeFlag(dfCollapsed, wbCollapseOther),
           wbStruct('Island Data', [
             wbStruct('Navmesh Bounds', [
-              wbVec3('Min'),
-              wbVec3('Max')
+              wbVec3IgnoreEmpty('Min'),
+              wbVec3IgnoreEmpty('Max')
             ]),
-            wbInteger('Vertex Count', itU16),
-            wbInteger('Triangle Count', itU16),
+            wbInteger('Vertex Count', itU16, nil, cpNormalIgnoreEmpty),
+            wbInteger('Triangle Count', itU16, nil, cpNormalIgnoreEmpty),
             wbArray('Vertices',
-              wbVec3('Vertex')
-            ).SetCountPath('Vertex Count', True)
+              wbVec3IgnoreEmpty('Vertex'),
+            -1, nil, cpNormalIgnoreEmpty).SetCountPath('Vertex Count', True)
              .IncludeFlag(dfCollapsed, wbCollapseVertices)
              .IncludeFlag(dfNotAlignable),
             wbArray('Triangles',
               wbStruct('Triangle', [
-                wbInteger('Vertex 0', itU16),
-                wbInteger('Vertex 1', itU16),
-                wbInteger('Vertex 2', itU16)
-              ]).IncludeFlag(dfCollapsed, wbCollapseVertices)
-            ).SetCountPath('Triangle Count', True)
+                wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
+              ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
+            -1, cpNormalIgnoreEmpty).SetCountPath('Triangle Count', True)
              .IncludeFlag(dfCollapsed, wbCollapseVertices)
              .IncludeFlag(dfNotAlignable)
           ]).SetSummaryKey([4])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
         ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbFloat('Preferred %')
-      ]).SetSummaryKeyOnValue([1,2,5])
+        wbFloat('Preferred %', cpNormalIgnoreEmpty)
+      ], cpNormalIgnoreEmpty).SetSummaryKeyOnValue([1,2,5])
         .SetSummaryPrefixSuffixOnValue(1, '', '')
         .SetSummaryPrefixSuffixOnValue(2, 'in ', '')
         .SetSummaryPrefixSuffixOnValue(5, 'is island with ', '')
@@ -4766,10 +4766,10 @@ begin
     wbRArrayS('Navmesh Connections',
       wbStructSK(NVCI, [0], 'Connection', [
         wbFormIDCk('Navmesh', [NAVM]),
-        wbArrayS('Standard', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Door Links', wbFormIDCk('Door', [REFR]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
-      ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+        wbArrayS('Standard', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Door Links', wbFormIDCk('Door', [REFR], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+      ], cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
     ).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
   ]);
 

--- a/Core/wbDefinitionsFO4.pas
+++ b/Core/wbDefinitionsFO4.pas
@@ -7637,45 +7637,44 @@ begin
     wbInteger(NVER, 'Version', itU32),
     wbRArrayS('Navmesh Infos',
       wbStructSK(NVMI, [0], 'Navmesh Info', [
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
         wbInteger('Flags', itU32,
           wbFlags(wbSparseFlags([
           5, 'Is Island',
           6, 'Not Edited'
-          ], False, 7))
-        ).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbVec3('Approx Location'),
-        wbFloat('Preferred %'),
-        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+          ], False, 7)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbVec3IgnoreEmpty('Approx Location'),
+        wbFloat('Preferred %', cpNormalIgnoreEmpty),
+        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbArrayS('Door Links',
           wbStructSK([1], 'Door Link', [
-            wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
-            wbFormIDCk('Door Ref', [REFR])
+            wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingDoor'),
+            wbFormIDCk('Door Ref', [REFR], false, cpNormalIgnoreEmpty)
           ]).SetSummaryKey([1])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
             .IncludeFlag(dfSummaryMembersNoName),
-        -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbStruct('Optional Island Data', [
-          wbInteger('Has Island Data', itU8, wbBoolEnum).SetAfterSet(wbUpdateSameParentUnions),
+          wbInteger('Has Island Data', itU8, wbBoolEnum, cpNormalIgnoreEmpty).SetAfterSet(wbUpdateSameParentUnions),
           wbUnion('Island Data', wbNAVIIslandDataDecider, [
             wbStruct('Unused', [wbEmpty('Unused')]).IncludeFlag(dfCollapsed, wbCollapseOther),
             wbStruct('Island Data', [
               wbStruct('Navmesh Bounds', [
-                wbVec3('Min'),
-                wbVec3('Max')
+                wbVec3IgnoreEmpty('Min'),
+                wbVec3IgnoreEmpty('Max')
               ]),
               wbArray('Triangles',
                 wbStruct('Triangle', [
-                  wbInteger('Vertex 0', itU16),
-                  wbInteger('Vertex 1', itU16),
-                  wbInteger('Vertex 2', itU16)
+                  wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
                 ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable),
               wbArray('Vertices',
-                wbVec3('Vertex'),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+                wbVec3IgnoreEmpty('Vertex'),
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable)
             ]).SetSummaryKey([1])
               .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -7685,19 +7684,19 @@ begin
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
           .IncludeFlag(dfSummaryMembersNoName),
         wbStruct('Pathing Cell', [
-          wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingCell'),
-          wbFormIDCk('Parent World', [WRLD, NULL]).IncludeFlag(dfSummaryExcludeNull),
+          wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingCell'),
+          wbFormIDCk('Parent World', [WRLD, NULL], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryExcludeNull),
           wbUnion('', wbNAVIParentDecider, [
             wbStruct('Coordinates', [
-              wbInteger('Grid Y', itS16),
-              wbInteger('Grid X', itS16)
+              wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+              wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
             ]).SetSummaryKey([1, 0])
               .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
               .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
               .SetSummaryDelimiter(', ')
               .IncludeFlag(dfCollapsed, wbCollapsePlacement)
               .IncludeFlag(dfSummaryMembersNoName),
-            wbFormIDCk('Parent Cell', [CELL])
+            wbFormIDCk('Parent Cell', [CELL], false, cpNormalIgnoreEmpty)
           ]).IncludeFlag(dfCollapsed, wbCollapsePlacement)
         ]).SetSummaryKey([1, 2])
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -7723,7 +7722,7 @@ begin
         ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
       -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
     ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM])).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
   ]);
 
   wbRecord(EXPL, 'Explosion', [
@@ -12854,22 +12853,20 @@ begin
     )
   ]);
 
-  wbRecord(NOCM, 'Navmesh Obstacle Manager', [
+  wbRecord(NOCM, 'Navmesh Obstacle Cover Manager', [
     wbEDID,
     wbRArray('Unknown',
-      wbRStruct('Unknown', [
-        wbInteger(INDX, 'Index', itU32),
-        wbRArray('Unknown datas',
-          wbStruct(DATA, 'Unknown data', [
-            wbByteArray('Unknown 1',2),
-            wbByteArray('Unknown 2',2),
-            wbByteArray('Unknown 4',4)
-          ])
-        ),
-        wbUnknown(INTV),
-        wbString(NAM1, 'Model')
-      ])
-    )
+        wbRStruct('Unknown', [
+          wbInteger(INDX, 'Index', itU32),
+          wbRArray('Unknown Datas',
+            wbStruct(DATA, 'Unknown Data', [
+              wbByteArray('Unknown 1',2),
+              wbByteArray('Unknown 2',2),
+              wbByteArray('Unknown 3',4)
+            ])),
+        wbUnknown(INTV)
+      ])),
+      wbString(NAM1, 'Model')
   ]);
 
   wbRecord(NOTE, 'Note', [

--- a/Core/wbDefinitionsFO76.pas
+++ b/Core/wbDefinitionsFO76.pas
@@ -9664,45 +9664,44 @@ begin
     wbInteger(NVER, 'Version', itU32),
     wbRArrayS('Navmesh Infos',
       wbStructSK(NVMI, [0], 'Navmesh Info', [
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
         wbInteger('Flags', itU32,
           wbFlags(wbSparseFlags([
           5, 'Is Island',
           6, 'Not Edited'
-          ], False, 7))
-        ).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbVec3('Approx Location'),
-        wbFloat('Preferred %'),
-        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+          ], False, 7)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbVec3IgnoreEmpty('Approx Location'),
+        wbFloat('Preferred %', cpNormalIgnoreEmpty),
+        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbArrayS('Door Links',
           wbStructSK([1], 'Door Link', [
-            wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
-            wbFormIDCk('Door Ref', [REFR])
+            wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingDoor'),
+            wbFormIDCk('Door Ref', [REFR], false, cpNormalIgnoreEmpty)
           ]).SetSummaryKey([1])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
             .IncludeFlag(dfSummaryMembersNoName),
-        -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbStruct('Optional Island Data', [
-          wbInteger('Has Island Data', itU8, wbBoolEnum).SetAfterSet(wbUpdateSameParentUnions),
+          wbInteger('Has Island Data', itU8, wbBoolEnum, cpNormalIgnoreEmpty).SetAfterSet(wbUpdateSameParentUnions),
           wbUnion('Island Data', wbNAVIIslandDataDecider, [
             wbStruct('Unused', [wbEmpty('Unused')]).IncludeFlag(dfCollapsed, wbCollapseOther),
             wbStruct('Island Data', [
               wbStruct('Navmesh Bounds', [
-                wbVec3('Min'),
-                wbVec3('Max')
+                wbVec3IgnoreEmpty('Min'),
+                wbVec3IgnoreEmpty('Max')
               ]),
               wbArray('Triangles',
                 wbStruct('Triangle', [
-                  wbInteger('Vertex 0', itU16),
-                  wbInteger('Vertex 1', itU16),
-                  wbInteger('Vertex 2', itU16)
+                  wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
                 ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
-                 .IncludeFlag(dfNotAlignable, wbCollapseNavmesh),
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
+                 .IncludeFlag(dfNotAlignable),
               wbArray('Vertices',
-                wbVec3('Vertex'),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+                wbVec3IgnoreEmpty('Vertex'),
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable)
             ]).SetSummaryKey([1])
               .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -9712,19 +9711,19 @@ begin
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
           .IncludeFlag(dfSummaryMembersNoName),
         wbStruct('Pathing Cell', [
-          wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingCell'),
-          wbFormIDCk('Parent World', [WRLD, NULL]).IncludeFlag(dfSummaryExcludeNull),
+          wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingCell'),
+          wbFormIDCk('Parent World', [WRLD, NULL], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryExcludeNull),
           wbUnion('', wbNAVIParentDecider, [
             wbStruct('Coordinates', [
-              wbInteger('Grid Y', itS16),
-              wbInteger('Grid X', itS16)
+              wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+              wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
             ]).SetSummaryKey([1, 0])
               .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
               .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
               .SetSummaryDelimiter(', ')
               .IncludeFlag(dfCollapsed, wbCollapsePlacement)
               .IncludeFlag(dfSummaryMembersNoName),
-            wbFormIDCk('Parent Cell', [CELL])
+            wbFormIDCk('Parent Cell', [CELL], false, cpNormalIgnoreEmpty)
           ]).IncludeFlag(dfCollapsed, wbCollapsePlacement)
         ]).SetSummaryKey([1, 2])
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -9750,7 +9749,7 @@ begin
         ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
       -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
     ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM]) ).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty) ).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
   ]);
 
    wbRecord(EXPL, 'Explosion', [
@@ -16067,21 +16066,20 @@ begin
     )
   ]);
 
-  wbRecord(NOCM, 'Navmesh Obstacle Manager', [
+  wbRecord(NOCM, 'Navmesh Obstacle Cover Manager', [
+    wbEDID,
     wbRArray('Unknown',
-      wbRStruct('Unknown', [
-        wbInteger(INDX, 'Index', itU32),
-        wbRArray('Unknown datas',
-          wbStruct(DATA, 'Unknown data', [
-            wbByteArray('Unknown 1',2),
-            wbByteArray('Unknown 2',2),
-            wbByteArray('Unknown 4',4)
-          ])
-        ),
-        wbUnknown(INTV),
-        wbString(NAM1, 'Model')
-      ])
-    )
+        wbRStruct('Unknown', [
+          wbInteger(INDX, 'Index', itU32),
+          wbRArray('Unknown Datas',
+            wbStruct(DATA, 'Unknown Data', [
+              wbByteArray('Unknown 1',2),
+              wbByteArray('Unknown 2',2),
+              wbByteArray('Unknown 3',4)
+            ])),
+        wbUnknown(INTV)
+      ])),
+      wbString(NAM1, 'Model')
   ]);
 
   wbUITE := wbEnum([

--- a/Core/wbDefinitionsSF1.pas
+++ b/Core/wbDefinitionsSF1.pas
@@ -9680,42 +9680,41 @@ begin
     wbInteger(NVER, 'Version', itU32),
     wbRArrayS('Navmesh Infos',
       wbStructSK(NVMI, [0], 'Navmesh Info', [
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
         wbInteger('Flags', itU32,
           wbFlags(wbSparseFlags([
           5, 'Is Island',
           6, 'Not Edited'
-          ], False, 7))
-        ).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbVec3('Approx Location'),
-        wbFloat('Preferred %'),
-        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+          ], False, 7)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbVec3IgnoreEmpty('Approx Location'),
+        wbFloat('Preferred %', cpNormalIgnoreEmpty),
+        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbArrayS('Door Links',
           wbStructSK([1], 'Door Link', [
-            wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
-            wbFormIDCk('Door Ref', [REFR])
+            wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingDoor'),
+            wbFormIDCk('Door Ref', [REFR], false, cpNormalIgnoreEmpty)
           ]).SetSummaryKey([1])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
             .IncludeFlag(dfSummaryMembersNoName),
-        -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbArray('Traversals',
           wbStruct('Traversal', [
-            wbInteger('Type', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingTraversalLink'),
-            wbFormIDCk('Cell or Object', [CELL, REFR]),
-            wbFormIDCk('Traversal', [TRAV, REFR]),
-            wbVec3('From Position'),
-            wbVec3('To Position'),
-            wbFloat,
-            wbFloat,
-            wbFloat,
+            wbInteger('Type', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingTraversalLink'),
+            wbFormIDCk('Cell or Object', [CELL, REFR], false, cpNormalIgnoreEmpty),
+            wbFormIDCk('Traversal', [TRAV, REFR], false, cpNormalIgnoreEmpty),
+            wbVec3IgnoreEmpty('From Position'),
+            wbVec3IgnoreEmpty('To Position'),
+            wbFloat('Unknown', cpNormalIgnoreEmpty),
+            wbFloat('Unknown', cpNormalIgnoreEmpty),
+            wbFloat('Unknown', cpNormalIgnoreEmpty),
             wbInteger('Flags', itU32,
               wbFlags(wbSparseFlags([
                 1, 'Unknown 1',
                 2, 'Unknown 2'
-              ]))).IncludeFlag(dfCollapsed, wbCollapseFlags),
-            wbFormIDCk('From Navmesh', [NAVM]),
-            wbFormIDCk('To Navmesh', [NAVM])
+              ])), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+            wbFormIDCk('From Navmesh', [NAVM], false, cpNormalIgnoreEmpty),
+            wbFormIDCk('To Navmesh', [NAVM], false, cpNormalIgnoreEmpty)
           ]).SetSummaryKey([2, 1, 3, 9, 4, 10])
             .SetSummaryMemberPrefixSuffix(2, '', '')
             .SetSummaryMemberPrefixSuffix(1, 'in/with ', '')
@@ -9725,27 +9724,27 @@ begin
             .SetSummaryMemberPrefixSuffix(10, 'in ', '')
             .IncludeFlag(dfCollapsed, wbCollapseTraversal)
             .IncludeFlag(dfSummaryMembersNoName),
-        -1).IncludeFlag(dfCollapsed, wbCollapseTraversal),
+        -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseTraversal),
         wbStruct('Optional Island Data', [
-          wbInteger('Has Island Data', itU8, wbBoolEnum).SetAfterSet(wbUpdateSameParentUnions),
+          wbInteger('Has Island Data', itU8, wbBoolEnum, cpNormalIgnoreEmpty).SetAfterSet(wbUpdateSameParentUnions),
           wbUnion('Island Data', wbNAVIIslandDataDecider, [
             wbStruct('Unused', [wbEmpty('Unused')]).IncludeFlag(dfCollapsed, wbCollapseOther),
             wbStruct('Island Data', [
               wbStruct('Navmesh Bounds', [
-                wbVec3('Min'),
-                wbVec3('Max')
+                wbVec3IgnoreEmpty('Min'),
+                wbVec3IgnoreEmpty('Max')
               ]),
               wbArray('Triangles',
                 wbStruct('Triangle', [
-                  wbInteger('Vertex 0', itU16),
-                  wbInteger('Vertex 1', itU16),
-                  wbInteger('Vertex 2', itU16)
+                  wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
                 ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable),
               wbArray('Vertices',
-                wbVec3('Vertex'),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+                wbVec3IgnoreEmpty('Vertex'),
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable)
             ]).SetSummaryKey([1])
               .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -9755,25 +9754,25 @@ begin
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
           .IncludeFlag(dfSummaryMembersNoName),
         wbStruct('Pathing Cell', [
-          wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingCell'),
-          wbFormIDCk('Parent World', [CELL, WRLD, NULL]).IncludeFlag(dfSummaryExcludeNull),
+          wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingCell'),
+          wbFormIDCk('Parent World', [CELL, WRLD, NULL], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryExcludeNull),
           wbUnion('', wbNAVIParentDecider, [
             wbStruct('Coordinates', [
-              wbInteger('Grid Y', itS16),
-              wbInteger('Grid X', itS16)
+              wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+              wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
             ]).SetSummaryKey([1, 0])
               .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
               .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
               .SetSummaryDelimiter(', ')
               .IncludeFlag(dfCollapsed, wbCollapsePlacement)
               .IncludeFlag(dfSummaryMembersNoName),
-            wbFormIDCk('Parent Cell', [CELL])
+            wbFormIDCk('Parent Cell', [CELL], false, cpNormalIgnoreEmpty)
           ]).IncludeFlag(dfCollapsed, wbCollapsePlacement)
         ]).SetSummaryKey([1, 2])
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
           .IncludeFlag(dfSummaryMembersNoName, wbCollapseNavmesh),
-        wbUnknown(1),
-        wbArray('Unknown', wbInteger('Type', itU32, wbCRCValuesEnum), -1)
+        wbUnknown(1, cpNormalIgnoreEmpty),
+        wbArray('Unknown', wbInteger('Type', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty), -1, cpNormalIgnoreEmpty)
       ]).SetSummaryKeyOnValue([0, 9, 7, 8])
         .SetSummaryPrefixSuffixOnValue(0, '', '')
         .SetSummaryPrefixSuffixOnValue(9, 'in ', '')
@@ -16474,17 +16473,17 @@ begin
   wbRecord(NOCM, 'Navmesh Obstacle Cover Manager', [
     wbEDID,
     wbRArray('Unknown',
-      wbRStruct('Unknown', [
-        wbInteger(INDX, 'Index', itU32),
-        wbRArray('Unknown datas',
-          wbStruct(DATA, 'Unknown data', [
-            wbUnknown
-          ])
-        ),
-        wbUnknown(INTV),
-        wbString(NAM1, 'Model')
-      ])
-    )
+        wbRStruct('Unknown', [
+          wbInteger(INDX, 'Index', itU32),
+          wbRArray('Unknown Datas',
+            wbStruct(DATA, 'Unknown Data', [
+              wbByteArray('Unknown 1',2),
+              wbByteArray('Unknown 2',2),
+              wbByteArray('Unknown 3',4)
+            ])),
+        wbUnknown(INTV)
+      ])),
+      wbString(NAM1, 'Model')
   ]);
 
   var wbStarSlot :=

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -5880,45 +5880,44 @@ begin
     wbInteger(NVER, 'Version', itU32),
     wbRArrayS('Navmesh Infos',
       wbStructSK(NVMI, [0], 'Navmesh Info', [
-        wbFormIDCk('Navmesh', [NAVM]).IncludeFlag(dfSummaryNoName),
+        wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryNoName),
         wbInteger('Flags', itU32,
           wbFlags(wbSparseFlags([
           5, 'Is Island',
           6, 'Not Edited'
-          ], False, 7))
-        ).IncludeFlag(dfCollapsed, wbCollapseFlags),
-        wbVec3('Approx Location'),
-        wbFloat('Preferred %'),
-        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+          ], False, 7)), cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseFlags),
+        wbVec3IgnoreEmpty('Approx Location'),
+        wbFloat('Preferred %', cpNormalIgnoreEmpty),
+        wbArrayS('Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArrayS('Preferred Edge Links', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbArrayS('Door Links',
           wbStructSK([1], 'Door Link', [
-            wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingDoor'),
-            wbFormIDCk('Door Ref', [REFR])
+            wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingDoor'),
+            wbFormIDCk('Door Ref', [REFR], false, cpNormalIgnoreEmpty)
           ]).SetSummaryKey([1])
             .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
             .IncludeFlag(dfSummaryMembersNoName),
-        -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
         wbStruct('Optional Island Data', [
-          wbInteger('Has Island Data', itU8, wbBoolEnum).SetAfterSet(wbUpdateSameParentUnions),
+          wbInteger('Has Island Data', itU8, wbBoolEnum, cpNormalIgnoreEmpty).SetAfterSet(wbUpdateSameParentUnions),
           wbUnion('Island Data', wbNAVIIslandDataDecider, [
-            wbStruct('Unused', [wbEmpty('Unused')]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+            wbStruct('Unused', [wbEmpty('Unused')]).IncludeFlag(dfCollapsed, wbCollapseOther),
             wbStruct('Island Data', [
               wbStruct('Navmesh Bounds', [
-                wbVec3('Min'),
-                wbVec3('Max')
+                wbVec3IgnoreEmpty('Min'),
+                wbVec3IgnoreEmpty('Max')
               ]),
               wbArray('Triangles',
                 wbStruct('Triangle', [
-                  wbInteger('Vertex 0', itU16),
-                  wbInteger('Vertex 1', itU16),
-                  wbInteger('Vertex 2', itU16)
+                  wbInteger('Vertex 0', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 1', itU16, nil, cpNormalIgnoreEmpty),
+                  wbInteger('Vertex 2', itU16, nil, cpNormalIgnoreEmpty)
                 ]).IncludeFlag(dfCollapsed, wbCollapseVertices),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable),
               wbArray('Vertices',
-                wbVec3('Vertex'),
-              -1).IncludeFlag(dfCollapsed, wbCollapseVertices)
+                wbVec3IgnoreEmpty('Vertex'),
+              -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseVertices)
                  .IncludeFlag(dfNotAlignable)
             ]).SetSummaryKey([1])
               .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -5928,19 +5927,19 @@ begin
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
           .IncludeFlag(dfSummaryMembersNoName),
         wbStruct('Pathing Cell', [
-          wbInteger('CRC Hash', itU32, wbCRCValuesEnum).SetDefaultEditValue('PathingCell'),
-          wbFormIDCk('Parent World', [WRLD, NULL]).IncludeFlag(dfSummaryExcludeNull),
+          wbInteger('CRC Hash', itU32, wbCRCValuesEnum, cpNormalIgnoreEmpty).SetDefaultEditValue('PathingCell'),
+          wbFormIDCk('Parent World', [WRLD, NULL], false, cpNormalIgnoreEmpty).IncludeFlag(dfSummaryExcludeNull),
           wbUnion('', wbNAVIParentDecider, [
             wbStruct('Coordinates', [
-              wbInteger('Grid Y', itS16),
-              wbInteger('Grid X', itS16)
+              wbInteger('Grid Y', itS16, nil, cpNormalIgnoreEmpty),
+              wbInteger('Grid X', itS16, nil, cpNormalIgnoreEmpty)
             ]).SetSummaryKey([1, 0])
               .SetSummaryMemberPrefixSuffix(0, 'Y: ', '>')
               .SetSummaryMemberPrefixSuffix(1, '<X: ', '')
               .SetSummaryDelimiter(', ')
               .IncludeFlag(dfCollapsed, wbCollapsePlacement)
               .IncludeFlag(dfSummaryMembersNoName),
-            wbFormIDCk('Parent Cell', [CELL])
+            wbFormIDCk('Parent Cell', [CELL], false, cpNormalIgnoreEmpty)
           ]).IncludeFlag(dfCollapsed, wbCollapsePlacement)
         ]).SetSummaryKey([1, 2])
           .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
@@ -5950,11 +5949,14 @@ begin
         .SetSummaryPrefixSuffixOnValue(8, 'in ', '')
         .SetSummaryPrefixSuffixOnValue(7, 'is island with ', '')
         .IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+        .IncludeFlag(dfFastAssign)
         .IncludeFlag(dfSummaryMembersNoName)
     ).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
     wbStruct(NVPP, 'Precomputed Pathing', [
       wbArray('Precomputed Paths',
-        wbArray('Path', wbFormIDCk('Navmesh', [NAVM]), -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
+        wbArray('Path',
+          wbFormIDCk('Navmesh', [NAVM]),
+        -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
       -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
       wbArrayS('Road Marker Index',
         wbStructSK([1], 'Road Marker', [
@@ -5963,10 +5965,10 @@ begin
         ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
       -1).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
     ]).IncludeFlag(dfCollapsed, wbCollapseNavmesh),
-    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM])).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
+    wbArrayS(NVSI, 'Deleted Navmeshes', wbFormIDCk('Navmesh', [NAVM], false, cpNormalIgnoreEmpty), -1, cpNormalIgnoreEmpty).IncludeFlag(dfCollapsed, wbCollapseNavmesh)
   ]);
 
-   wbRecord(EXPL, 'Explosion', [
+  wbRecord(EXPL, 'Explosion', [
     wbEDID,
     wbVMAD,
     wbOBND(True),

--- a/Core/wbInterface.pas
+++ b/Core/wbInterface.pas
@@ -283,6 +283,7 @@ var
   wbCompareRawData                   : Boolean    = False;
   wbDisableFormIDCheck               : Boolean    = False;
   wbComplexFileFileID                : Boolean    = False;
+  wbAllowCompareNAVI                 : Boolean    = False;
 
   wbCS                               : Boolean    = False;
   wbOBME                             : Boolean    = False;

--- a/xEdit/xeInit.pas
+++ b/xEdit/xeInit.pas
@@ -1147,6 +1147,9 @@ begin
   begin
     wbIKnowWhatImDoing := True;
 
+    if FIndCmdLineSwitch('CompareNAVI') then
+      wbAllowCompareNAVI := True;
+
     if FindCmdLineSwitch('AllowMakePartial') then
       wbAllowMakePartial := True;
 

--- a/xEdit/xeMainForm.pas
+++ b/xEdit/xeMainForm.pas
@@ -14525,7 +14525,7 @@ begin
     end;
     SetLength(MainRecords, j);
 
-  end else if (aMainRecord.Signature = 'NAVI') (* or (aMainRecord.Signature = 'TES4') *) then begin
+  end else if (aMainRecord.Signature = 'NAVI') and (wbAllowCompareNAVI = False) then begin
     Signature := aMainRecord.Signature;
     FormID := aMainRecord.FormID;
     LoadOrder := aMainRecord.GetFile.LoadOrder;


### PR DESCRIPTION
Not intended for merge.

Added ability to compare NAVI. Simply an experiment for a project I am working on. It helped locate a bug which was causing pathfinding problems.

Also updated NOCM. The model string comes after all of the index nodes and their unknown data, not for each node.

This can be toggled with the command line param CompareNAVI and requires IKnowWhatIAmDoing (probably should've locked it behind IKnowThisWillBreakMyGame).