### PR TITLE
Improve script execution performance by skipping empty Initialize, Process, and Finalize functions

### DIFF
--- a/xEdit/JvI/xejviScriptHost.pas
+++ b/xEdit/JvI/xejviScriptHost.pas
@@ -50,6 +50,7 @@ type
     { IxeScript }
     function CallFunction(const aName: string; const aParams: array of Variant): Variant;
     function FunctionExists(const aName: string): Boolean;
+    function FunctionIsEmpty(const aName: string): Boolean;
     function GetLastErrorLocation: string;
   public
     destructor Destroy; override;
@@ -834,6 +835,50 @@ end;
 function TxejviScript.FunctionExists(const aName: string): Boolean;
 begin
   Result := FProgram.FunctionExists('', aName);
+end;
+
+function TxejviScript.FunctionIsEmpty(const aName: string): Boolean;
+var
+  FunctionDesc: TJvInterpreterFunctionDesc;
+  Body: string;
+  P, I: Integer;
+begin
+  Result := False;
+  FunctionDesc := nil;
+  for I := FProgram.Adapter.SrcFunctionList.Count - 1 downto 0 do begin
+    var SrcFun := TJvInterpreterSrcFunction(FProgram.Adapter.SrcFunctionList.Items[I]);
+    if SameText(SrcFun.FunctionDesc.Identifier, aName) then begin
+      FunctionDesc := SrcFun.FunctionDesc;
+      Break;
+    end;
+  end;
+  if not Assigned(FunctionDesc) then
+    Exit;
+
+  Body := Copy(FScript, FunctionDesc.PosBeg, FunctionDesc.PosEnd - FunctionDesc.PosBeg);
+  Body := LowerCase(Body);
+
+  // skip any var section before begin
+  P := Pos('begin', Body);
+  if P = 0 then
+    Exit;
+  Body := Copy(Body, P, Length(Body) - P + 1);
+
+  // strip all whitespace to normalize
+  I := 1;
+  while I <= Length(Body) do
+    if CharInSet(Body[I], [' ', #9, #10, #13]) then
+      Delete(Body, I, 1)
+    else
+      Inc(I);
+
+  // trivially empty: no statements, or only Result := 0
+  Result := (Body = 'beginend') or
+            (Body = 'beginend;') or
+            (Body = 'beginend.') or
+            (Body = 'beginresult:=0;end') or
+            (Body = 'beginresult:=0;end;') or
+            (Body = 'beginresult:=0;end.');
 end;
 
 function TxejviScript.GetLastErrorLocation: string;

--- a/xEdit/xeMainForm.pas
+++ b/xEdit/xeMainForm.pas
@@ -8463,7 +8463,7 @@ begin
         NavCleanupCollapsedNodeChildren;
         try
           try
-            if Script.FunctionExists('Initialize') then begin
+            if Script.FunctionExists('Initialize') and not Script.FunctionIsEmpty('Initialize') then begin
               var Result: Variant;
               Inc(wbHideStartTime);
               try
@@ -8477,14 +8477,14 @@ begin
               end;
             end;
 
-            // skip selected records iteration if Process() function doesn't exist
-            if Script.FunctionExists('Process') then
+            // skip selected records iteration if Process() function doesn't exist or is empty
+            if Script.FunctionExists('Process') and not Script.FunctionIsEmpty('Process') then
               if not aRefByMode then
                 ApplyScriptToSelection(SelectedNodes, Count, bShowMessages)
               else
                 ApplyScriptToSelection(SelectedElements, Count, bShowMessages);
 
-            if Script.FunctionExists('Finalize') then begin
+            if Script.FunctionExists('Finalize') and not Script.FunctionIsEmpty('Finalize') then begin
               var Result: Variant;
               Inc(wbHideStartTime);
               try

--- a/xEdit/xeScriptHost.pas
+++ b/xEdit/xeScriptHost.pas
@@ -23,6 +23,7 @@ type
     ['{3BE80702-B634-46EB-8A45-38D9D911E6B6}']
 
     function FunctionExists(const aName: string): Boolean;
+    function FunctionIsEmpty(const aName: string): Boolean;
     function CallFunction(const aName: string; const aParams: array of Variant): Variant;
     function GetLastErrorLocation: string;
   end;


### PR DESCRIPTION
This improves the performance of scripts where empty `Initialize`, `Process`, and/or `Finalize` functions exist and the user has selected many records.