### PR TITLE
CleanMasters: log each removed master by name

### DIFF
--- a/Core/wbImplementation.pas
+++ b/Core/wbImplementation.pas
@@ -3069,8 +3069,10 @@ begin
             New[High(New)] := TwbFileID.CreateFull(j);
           end;
           Inc(j);
-        end else
+        end else begin
+          flProgress('  Removing unused master: ' + flMasters[i].FileName);
           MasterFiles[i].SortOrder := $100;
+        end;
 
       var lRemovedCount := 0;
 


### PR DESCRIPTION
## Problem

When using **Clean Masters**, the Messages tab only reports a count:

```
Removed 2 unused masters.
```

There's no way to know *which* masters were removed without manually comparing the master list before and after, or running a separate script like `Report masters.pas`.

## Change

A single `flProgress` call added inside the loop that marks unused masters for removal — one line per removed master, printed before the existing summary:

```
  Removing unused master: UnusedDLC.esm
  Removing unused master: SomeMod.esp
Removed 2 unused masters.
```

## Implementation

`Core/wbImplementation.pas`, `TwbFile.CleanMasters` — the `else` branch that marks a master with `SortOrder = $100` (i.e. unused, will be removed) now also calls `flProgress` with the filename. The existing count summary at the end is unchanged.

**Diff is 3 lines** — no interface changes, no new variables, no behaviour change beyond the additional log output.

## Test plan

- [ ] Run Clean Masters on a plugin with one or more unused masters — confirm each removed name appears in Messages
- [ ] Run Clean Masters on a plugin where all masters are used — confirm no spurious output, count still reads "Removed 0 unused masters."
- [ ] Run Clean Masters on a plugin with no masters at all — confirm existing "Has no masters." path is unaffected