### PR TITLE
unmark Embedded Weapon flag on WEAP as unused

### DIFF
--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -2232,6 +2232,19 @@ begin
     Exit(1);
 end;
 
+function wbEmbeddedWeaponActorValueEnum: IwbEnumDef;
+begin
+  Result := wbEnum([
+    {0} 'Perception Condition',
+    {1} 'Endurance Condition',
+    {2} 'Left Attack Condition',
+    {3} 'Right Attack Condition',
+    {4} 'Left Mobility Condition',
+    {5} 'Right Mobility Condition',
+    {6} 'Brain Condition'
+  ]);
+end;
+
 procedure ReferenceRecord(const aSignature: TwbSignature; const aName: string);
 begin
   wbRefRecord(aSignature, aName,
@@ -10517,7 +10530,7 @@ begin
     wbDESC,
     wbTexturedModel('Has Scope', [MOD3, MO3T], [wbMO3S]),
     wbFormIDCK(EFSD, 'Scope Effect', [EFSH]),
-    wbByteArray(NNAM, 'Unused', 0, cpIgnore, False), // leftover
+    wbString(NNAM, 'Embedded Weapon Node),
     wbFormIDCk(INAM, 'Impact Data Set', [IPDS, NULL]),
     wbFormIDCk(WNAM, '1st Person Model Object', [STAT, NULL]),
     wbFormIDCk(SNAM, 'Attack Sound', [SNDR]),
@@ -10553,7 +10566,7 @@ begin
       wbInteger('Base VATS To-Hit Chance', itU8),
       wbInteger('Attack Animation', itU8, wbAttackAnimationEnum),
       wbInteger('# Projectiles', itU8),
-      wbInteger('Embedded Weapon AV (unused)', itU8),
+      wbInteger('Embedded Weapon Actor Value', itU8, wbEmbeddedWeaponActorValueEnum),
       wbFloat('Range Min'),
       wbFloat('Range Max'),
       wbInteger('On Hit', itU32, wbEnum([

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -2232,19 +2232,6 @@ begin
     Exit(1);
 end;
 
-function wbEmbeddedWeaponActorValueEnum: IwbEnumDef;
-begin
-  Result := wbEnum([
-    {0} 'Perception Condition',
-    {1} 'Endurance Condition',
-    {2} 'Left Attack Condition',
-    {3} 'Right Attack Condition',
-    {4} 'Left Mobility Condition',
-    {5} 'Right Mobility Condition',
-    {6} 'Brain Condition'
-  ]);
-end;
-
 procedure ReferenceRecord(const aSignature: TwbSignature; const aName: string);
 begin
   wbRefRecord(aSignature, aName,
@@ -10566,7 +10553,16 @@ begin
       wbInteger('Base VATS To-Hit Chance', itU8),
       wbInteger('Attack Animation', itU8, wbAttackAnimationEnum),
       wbInteger('# Projectiles', itU8),
-      wbInteger('Embedded Weapon Actor Value', itU8, wbEmbeddedWeaponActorValueEnum),
+      wbInteger('Embedded Weapon Actor Value', itU8, 
+        wbEnum([
+        {0} 'Perception Condition',
+        {1} 'Endurance Condition',
+        {2} 'Left Attack Condition',
+        {3} 'Right Attack Condition',
+        {4} 'Left Mobility Condition',
+        {5} 'Right Mobility Condition',
+        {6} 'Brain Condition'
+        ])),
       wbFloat('Range Min'),
       wbFloat('Range Max'),
       wbInteger('On Hit', itU32, wbEnum([

--- a/Core/wbDefinitionsTES5.pas
+++ b/Core/wbDefinitionsTES5.pas
@@ -10543,10 +10543,10 @@ begin
         {0x0004}'Has Scope (unused)',
         {0x0008}'Can''t Drop',
         {0x0010}'Hide Backpack (unused)',
-        {0x0020}'Embedded Weapon (unused)',
+        {0x0020}'Embedded Weapon',
         {0x0040}'Don''t Use 1st Person IS Anim (unused)',
         {0x0080}'Non-playable'
-      ], [1, 2, 4, 5, 6])).IncludeFlag(dfCollapsed, wbCollapseFlags),
+      ], [1, 2, 4, 6])).IncludeFlag(dfCollapsed, wbCollapseFlags),
       wbUnused(2),
       wbFloat('Sight FOV'),
       wbByteArray('Unknown', 4),


### PR DESCRIPTION
There is some evidence that the Embedded Weapon flag is not unused in Skyrim:
- It is enabled on Dwemer Ballista traps in Skyrim.esm
- Changing the state of the flag changes the game's behavior in certain situations. Namely, the game can crash in CombatBehaviorFindWeapon when nearby AMMOs have a null reference as their projectile. However, with this flag enabled on the WEAP, the crash does not occur.

I don't know whether the flag has more effects, but I think this is enough for it not to be marked unused.